### PR TITLE
Fix dead links

### DIFF
--- a/_changes.html
+++ b/_changes.html
@@ -4519,7 +4519,7 @@ SUBTITLE(Fixed in 7.5 - December 1 2000)
  BGF memory leaks removed
  BGF improved config file parser
  BGF config file parser crash fixed
- BGF ง in HTTP usernames or passwords made bad authorization headers.
+ BGF ยง in HTTP usernames or passwords made bad authorization headers.
 </ul>
 
 <a name="7_4_2"></a>

--- a/dev/_head.html
+++ b/dev/_head.html
@@ -16,7 +16,7 @@ TITLE(Automatic curl Builds)
 <b>Related:</b>
 <br><a href="http://cool.haxx.se/cvs.cgi/curl/">Browse CVS</a>
 <br><a href="http://cool.haxx.se/curl-daily/">Daily Snapshot</a>
-<br><a href="/changes.html/">Changelog</a>
+<br><a href="/changes.html">Changelog</a>
 </div>
 
 [<a href="./">build table</a>]

--- a/dev/_security.html
+++ b/dev/_security.html
@@ -16,7 +16,7 @@ TITLE(SECURITY -- how security vulnerabilities should be handled)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="/docs/security.html">Security</a>
-<br><a href="faq.html">FAQ</a>
+<br><a href="/docs/faq.html">FAQ</a>
 <br><a href="/changes.html">Changelog</a>
 </div>
 

--- a/docs/_contribute.html
+++ b/docs/_contribute.html
@@ -17,7 +17,7 @@ TITLE(Contribute -- How to Contribute Code)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="/mail/">Mailing Lists</a>
-<br><a href="internals.html">Internals</a>
+<br><a href="/dev/internals.html">Internals</a>
 </div>
 
 #include "contribute.t"

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -38,13 +38,13 @@ SUBTITLE(<a href="projdocs.html">The project</a>)
 <a href="install.html">Install</a>,
 <a href="knownbugs.html">Known Bugs</a>,
 <a href="todo.html">TODO</a>,
-<a href="/about.hmtl">Web Site Info</a>
+<a href="/about.html">Web Site Info</a>
 
 SUBTITLE(<a href="reldocs.html">Releases</a>)
 <p>
 <a href="/changes.html">Changelog</a>,
 <a href="releases.html">Release Table</a>,
-<a href="security.hmtl">Security</a>,
+<a href="security.html">Security</a>,
 <a href="versions.html">Version Nums</a>.
 <a href="vulnerabilities.html">Vulnerabilities</a>
 

--- a/docs/_programs.html
+++ b/docs/_programs.html
@@ -224,7 +224,7 @@ TITLE(Programs using curl for file transfers)
     changed to relative links, and links to active pages get changed to the
     resulting pages. (Tcl) </td>
    NEWCOL
-    <a href="mailto:ornalux_at_redestb.es">Andrés García</a> </td>
+    <a href="mailto:ornalux_at_redestb.es">AndrÃ©s GarcÃ­a</a> </td>
   TREND
 
   TREVEN

--- a/docs/_projdocs.html
+++ b/docs/_projdocs.html
@@ -28,7 +28,7 @@ TITLE(Project Documentation)
   can <a href="bugs.html">report the bug</a>.
 <p>
   Learn about the <a href="libs.html">dependencies</a> libcurl can use,
-  which <a href="features.hmtl">features</a> it has or how
+  which <a href="features.html">features</a> it has or how
   to <a href="install.html">install</a> it.
 
 <p>

--- a/docs/_tooldocs.html
+++ b/docs/_tooldocs.html
@@ -23,7 +23,7 @@ TITLE(Tool Documentation)
   The main tool to know and learn here is of course curl. Read the full
   reference <a href="manpage.html">man page</a>, read
   the <a href="manual.html">tutorial</a> or learn how to
-  do <a href="httpscripting">HTTP scripting</a> with curl.
+  do <a href="httpscripting.html">HTTP scripting</a> with curl.
 <p>
   The most common questions are collected in the <a href="faq.html">FAQ</a>.
   

--- a/libcurl/_competitors.html
+++ b/libcurl/_competitors.html
@@ -131,7 +131,7 @@ href="wininet.html">comparison with libcurl</a><br>
 <ul>
  (Windows) Provides client-side protocol support for communication with HTTP
  servers. A client computer can use the XMLHTTP object to send an arbitrary
- HTTP request, receive the response, and have the Microsoft® XML Document
+ HTTP request, receive the response, and have the MicrosoftÂ® XML Document
  Object Model (DOM) parse that response.
 </ul>
 

--- a/libcurl/lua/_index.html
+++ b/libcurl/lua/_index.html
@@ -24,7 +24,7 @@ to the functionality of Lua
 
 <p><b>Credits</b><br>
 luacurl is written by Alexander Marinov and Enrico Tassi <p>
-Lua-cURL is written by Jürgen Hötzel
+Lua-cURL is written by JÃ¼rgen HÃ¶tzel
 
 <p><b>What is Lua?</b><br>
  You'll find more info about Lua here:


### PR DESCRIPTION
Encountered a broken about URL earlier today and decided to look for others. The first commit fixes encoding issues which upset the Python parser, the second one fixes some dead links.

Excluded from the scans are:

        '_press.html', # External links
        '_newslog.html',
        '_changes.html',
        # Need to be checked!
        '_oldnews.html',
        '_oldnews2.html',

Those contained many dead (internal) links, those were skipped for now since they are very old.