### PR TITLE
libcurl-features: Move thread safety info to libcurl doc

### DIFF
--- a/libcurl/_features.html
+++ b/libcurl/_features.html
@@ -55,31 +55,9 @@ SUBTITLE(Portable!)
 <a name="thread"></a>
 SUBTITLE(Thread Safe!)
 <p>
- libcurl is designed and implemented entirely thread safe. There are some
- considerations to keep in mind when using libcurl in multiple threads though,
- as mentioned below:
-<p>
- <b>Never</b> share libcurl handles between multiple threads. You should only
- use one handle in one single thread at any given time. You can still share
- certain data between multiple threads by using the <a
- href="/libcurl/c/libcurl-share.html">share interface</a>.
-<p>
- libcurl uses certain system calls to obtain information. Some of the most
- crucial ones are the name resoluition calls (the <i>gethostby*</i>
- family). It is very important that libcurl found and can use thread safe
- versions of these and other system calls, as otherwise it can't function
- fully thread safe.
-<p>
- Some operating systems are known to have faulty thread implementations. We
- have previously received problem reports on *BSD (at least in the past, they
- may be working fine these days). Some operating systems that are known to
- have solid and working thread support are Linux, Solaris and Windows.
-<p>
- Further, if you use any SSL/TLS-based protocol (HTTPS or FTPS) you need to
- setup OpenSSL or GnuTLS callbacks for synch. See the <a
- href="http://curl.haxx.se/libcurl/c/libcurl-tutorial.html#Multi-threading">libcurl-tutorial(3)</a>
- man page for details.
-
+ libcurl is thread safe but there are a few exceptions. Refer to <a
+ href="http://curl.haxx.se/libcurl/c/libcurl-thread.html">libcurl-thread(3)</a>
+ for more information.
 
 <a name="features"></a>
 SUBTITLE(Unmatched Set of Features!)


### PR DESCRIPTION
The thread safety information in this file has been consolidated in
libcurl's documentation libcurl-thread.3. We now point to that document
instead.

---
See bagder/curl#341