### PR TITLE
lua: update link for lua-curl binding

### DIFF
--- a/libcurl/lua/_index.html
+++ b/libcurl/lua/_index.html
@@ -17,14 +17,14 @@ TITLE(libcurl bindings for Lua)
 There are two different efforts:
 <ol>
 <li> <a href="http://luacurl.luaforge.net/">luacurl</a> adopts the easy interface
-<li> <a href="http://luaforge.net/projects/lua-curl/">Lua-cURL</a> is
+<li> <a href="https://github.com/Lua-cURL/Lua-cURLv3">Lua-cURL</a> is
 aiming for a full-fledged libcurl binding (easy/multi/share interface)
 to the functionality of Lua
 </ol>
 
 <p><b>Credits</b><br>
 luacurl is written by Alexander Marinov and Enrico Tassi <p>
-Lua-cURL is written by Jürgen Hötzel
+Lua-cURL is written by Jürgen Hötzel and maintained by <a href="https://github.com/moteus">Alexey Melnichuk</a>
 
 <p><b>What is Lua?</b><br>
  You'll find more info about Lua here:


### PR DESCRIPTION
It sounds to be the new home (http://msva.github.io/lua-curl/ gives a 404)