### PR TITLE
CVE-2025-0725.md: fix typo in zlib version

### DIFF
--- a/docs/CVE-2025-0725.md
+++ b/docs/CVE-2025-0725.md
@@ -23,7 +23,7 @@ vulnerable to a wide range of security problems and a user using this is
 already in a spectacularly bad position.
 
 libcurl featured code that at run-time takes a different code path for zlib
-versions before 1.0.2.4 because of lack of functionality in those old
+versions before 1.2.0.4 because of lack of functionality in those old
 versions, and this rarely used piece of code contained the vulnerable code
 path.
 


### PR DESCRIPTION
The second and third numbers of the zlib version were transposed.