### PR TITLE
windows: link to gpg and sha256 files

### DIFF
--- a/windows/_index.html
+++ b/windows/_index.html
@@ -47,16 +47,16 @@ TITLE(curl DEP_CURL for Windows)
   <a href="CURL_WIN64_ZIP"><img src="../pix/GS-Download-icon.svg" alt="Download 64-bit curl" width="90" height="90" style="float:left;"></a>
   <a href="CURL_WIN64_ZIP" class="windl">curl for 64-bit</a> <br>
 Size: CURL_WIN64_ZIP_SIZE<br>
-[<a href="CURL_WIN64_ZIP.asc">gpg</a>]
-[<a href="CURL_WIN64_ZIP.txt">sha256</a>]: SHA256_CURL_WIN64<br>
+<a href="CURL_WIN64_ZIP.asc">gpg</a> /
+<a href="CURL_WIN64_ZIP.txt">sha256</a>: SHA256_CURL_WIN64<br>
 
 #ifdef CURL_WIN64A_ZIP
 <p class="windl">
   <a href="CURL_WIN64A_ZIP"><img src="../pix/GS-Download-icon.svg" alt="Download 64-bit (ARM64) curl" width="90" height="90" style="float:left;"></a>
   <a href="CURL_WIN64A_ZIP" class="windl">curl for 64-bit (ARM64)</a> <br>
 Size: CURL_WIN64A_ZIP_SIZE<br>
-[<a href="CURL_WIN64A_ZIP.asc">gpg</a>]
-[<a href="CURL_WIN64A_ZIP.txt">sha256</a>]: SHA256_CURL_WIN64A<br>
+<a href="CURL_WIN64A_ZIP.asc">gpg</a> /
+<a href="CURL_WIN64A_ZIP.txt">sha256</a>: SHA256_CURL_WIN64A<br>
 #endif
 
 #ifdef CURL_WIN32_ZIP
@@ -64,8 +64,8 @@ Size: CURL_WIN64A_ZIP_SIZE<br>
   <a href="CURL_WIN32_ZIP"><img src="../pix/GS-Download-icon.svg" alt="Download 32-bit curl" width="90" height="90" style="float:left;"></a>
   <a href="CURL_WIN32_ZIP" class="windl">curl for 32-bit</a> <br>
 Size: CURL_WIN32_ZIP_SIZE<br>
-[<a href="CURL_WIN32_ZIP.asc">gpg</a>]
-[<a href="CURL_WIN32_ZIP.txt">sha256</a>]: SHA256_CURL_WIN32<br>
+<a href="CURL_WIN32_ZIP.asc">gpg</a> /
+<a href="CURL_WIN32_ZIP.txt">sha256</a>: SHA256_CURL_WIN32<br>
 #endif
 
 SUBTITLE(Fixed URLs)
@@ -73,17 +73,17 @@ SUBTITLE(Fixed URLs)
   These links automatically provide the latest curl package:
 <p>
 <a download="curl-win64-latest.zip" href="latest.cgi?p=win64-mingw.zip">curl for win64</a>
-[<a download="curl-win64-latest.zip.asc" href="latest.cgi?p=win64-mingw.zip.asc">gpg</a>]
-[<a download="curl-win64-latest.zip.txt" href="latest.cgi?p=win64-mingw.zip.txt">sha256</a>]<br>
+/ <a download="curl-win64-latest.zip.asc" href="latest.cgi?p=win64-mingw.zip.asc">gpg</a>
+/ <a download="curl-win64-latest.zip.txt" href="latest.cgi?p=win64-mingw.zip.txt">sha256</a><br>
 #ifdef CURL_WIN64A_ZIP
 <a download="curl-win64a-latest.zip" href="latest.cgi?p=win64a-mingw.zip">curl for win64 ARM64</a>
-[<a download="curl-win64a-latest.zip.asc" href="latest.cgi?p=win64a-mingw.zip.asc">gpg</a>]
-[<a download="curl-win64a-latest.zip.txt" href="latest.cgi?p=win64a-mingw.zip.txt">sha256</a>]<br>
+/ <a download="curl-win64a-latest.zip.asc" href="latest.cgi?p=win64a-mingw.zip.asc">gpg</a>
+/ <a download="curl-win64a-latest.zip.txt" href="latest.cgi?p=win64a-mingw.zip.txt">sha256</a><br>
 #endif
 #ifdef CURL_WIN32_ZIP
 <a download="curl-win32-latest.zip" href="latest.cgi?p=win32-mingw.zip">curl for win32</a>
-[<a download="curl-win32-latest.zip.asc" href="latest.cgi?p=win32-mingw.zip.asc">gpg</a>]
-[<a download="curl-win32-latest.zip.txt" href="latest.cgi?p=win32-mingw.zip.txt">sha256</a>]<br>
+/ <a download="curl-win32-latest.zip.asc" href="latest.cgi?p=win32-mingw.zip.asc">gpg</a>
+/ <a download="curl-win32-latest.zip.txt" href="latest.cgi?p=win32-mingw.zip.txt">sha256</a><br>
 #endif
 
 SUBTITLE(Specifications)


### PR DESCRIPTION
Also change download icon `src` to relative to make it work when opened
as local file.

---

I plan to extend it with `cosign` signature links on the next curl-for-win update.