### PR TITLE
download: make nicer release "boxes"

### DIFF
--- a/_changes.html
+++ b/_changes.html
@@ -3,11 +3,18 @@
 <head> <title>curl - Changes</title>
 #include "css.t"
 #include "changescss.t"
+  .thisver:before {
+      content: "✓";
+      padding: 5px 5px 5px 5px;
+  }
   .thisver {
       background-color: #e0e0e0;
       border: 1px solid black;
       border-radius: 10px;
       padding: 5px 5px 5px 5px;
+      margin: 5px 5px 5px 5px;
+      width: fit-content;
+      float: left;
   }
 </style>
 </head>

--- a/changes.t
+++ b/changes.t
@@ -1,19 +1,32 @@
 #define CHG <li>
 #define BGF <li>
 
+#ifdef CURL_CHANGES_IN_VERSION
 #define RELEASEVIDEO(ver,vid) \
-<div><a class="video" href=vid>ver</a> \
- <a class="vulnbox" href=/docs/vuln-ver.html>ver</a> \
- <a class="thisver" href=/ch/ver.html>ver changes only</a> \
-</div>
+<div class="video"><a href=vid>ver</a> </div>\
+<div class="vulnbox"><a href=/docs/vuln-ver.html>ver</a></div> \
+<div style="clear: both;">&nbsp;</div>
 
 #define VULNBOX(ver) \
-<div> \
- <a class="vulnbox" href=/docs/vuln-ver.html>ver</a> \
- <a class="thisver" href=/ch/ver.html>ver changes only</a> \
-</div>
+<div class="vulnbox"><a href=/docs/vuln-ver.html>ver</a></div> \
+<div style="clear: both;">&nbsp;</div>
+
+#define THISBOX(x)
+
+#else
+
+#define RELEASEVIDEO(ver,vid) \
+<div class="video"><a href=vid>ver</a> </div>\
+<div class="vulnbox"><a href=/docs/vuln-ver.html>ver</a></div> \
+<div class="thisver"><a href=/ch/ver.html>ver</a> changes only</div> \
+<div style="clear: both;">&nbsp;</div>
+
+#define VULNBOX(ver) \
+<div class="vulnbox"><a href=/docs/vuln-ver.html>ver</a></div> \
+<div class="thisver"><a href=/ch/ver.html>ver</a> changes only</div> \
+<div style="clear: both;">&nbsp;</div>
 
 #define THISBOX(ver) \
-<div> \
- <a class="thisver" href=/ch/ver.html>ver changes only</a> \
-</div>
+<div class="thisver"><a href=/ch/ver.html>ver</a> changes only</div> \
+<div style="clear: both;">&nbsp;</div>
+#endif

--- a/changescss.t
+++ b/changescss.t
@@ -3,15 +3,14 @@
       content: "🎥 release video for";
       padding: 5px 5px 5px 5px;
   }
-  .video:after {
-      content: "▶";
-      padding: 5px 5px 5px 5px;
-  }
   .video {
       background-color: #e0e0e0;
       border: 1px solid black;
       border-radius: 10px;
       padding: 5px 5px 5px 5px;
+      margin: 5px 5px 5px 5px;
+      width: fit-content;
+      float: left;
   }
   .vulnbox:before {
       content: "🐜 known vulnerabilities for";
@@ -22,7 +21,9 @@
       border: 1px solid black;
       border-radius: 10px;
       padding: 5px 5px 5px 5px;
-      line-height: 2.5;
+      margin: 5px 5px 5px 5px;
+      width: fit-content;
+      float: left;
   }
   h1 {
       margin-block-end: 0.3em;


### PR DESCRIPTION
The three separate boxes "release video", "known vulnerabilities" and "changes only" no longer get cut in the middle/word-wrapped if too wide, and they have some margin.

The "changes only" box gets a little left-side symbol too (a checkmark) for consistency and the link is only on the version number like in the other boxes.