### PR TITLE
GHA/make: add workaround for `roffit` install breakage

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           git clone https://github.com/bagder/roffit.git
           cd roffit
-          make install
+          install -Dm0755 roffit /usr/local/bin/roffit
 
       - name: bootstrap
         run: ./bootstrap.sh


### PR DESCRIPTION
Resolving:
```
Cloning into 'roffit'...
install -Dm0755 roffit /usr/local/bin/roffit
install -Dm0644 roffit.1 /usr/local/man/man1/roffit.1
install: cannot create regular file '/usr/local/man/man1/roffit.1': Permission denied
make: *** [Makefile:27: install] Error 1
Error: Process completed with exit code 2.
```
Ref: https://github.com/curl/curl-www/actions/runs/18038371623/job/51330618553?pr=486#step:7:7

Ref: https://github.com/bagder/roffit/commit/a565a8f718ff4b84e17a2e9cd2edf1fbbd7d49fb
