### PR TITLE
windows: rename cosign signatures from `.sigstore` to `.sigstore.json`

### DIFF
--- a/windows/_index.html
+++ b/windows/_index.html
@@ -48,7 +48,7 @@ TITLE(curl DEP_CURL for Windows)
   <a href="CURL_WIN64_ZIP" class="windl">curl for 64-bit (Intel)</a> <br>
 Size: CURL_WIN64_ZIP_SIZE<br>
 <a href="CURL_WIN64_ZIP.asc">pgp</a> /
-<a href="CURL_WIN64_ZIP.sigstore">cosign</a> /
+<a href="CURL_WIN64_ZIP.sigstore.json">cosign</a> /
 <a href="CURL_WIN64_ZIP.txt">sha256</a>: SHA256_CURL_WIN64<br>
 
 #ifdef CURL_WIN64A_ZIP
@@ -57,7 +57,7 @@ Size: CURL_WIN64_ZIP_SIZE<br>
   <a href="CURL_WIN64A_ZIP" class="windl">curl for 64-bit (ARM64)</a> <br>
 Size: CURL_WIN64A_ZIP_SIZE<br>
 <a href="CURL_WIN64A_ZIP.asc">pgp</a> /
-<a href="CURL_WIN64A_ZIP.sigstore">cosign</a> /
+<a href="CURL_WIN64A_ZIP.sigstore.json">cosign</a> /
 <a href="CURL_WIN64A_ZIP.txt">sha256</a>: SHA256_CURL_WIN64A<br>
 #endif
 
@@ -67,7 +67,7 @@ Size: CURL_WIN64A_ZIP_SIZE<br>
   <a href="CURL_WIN32_ZIP" class="windl">curl for 32-bit (Intel)</a> <br>
 Size: CURL_WIN32_ZIP_SIZE<br>
 <a href="CURL_WIN32_ZIP.asc">pgp</a> /
-<a href="CURL_WIN32_ZIP.sigstore">cosign</a> /
+<a href="CURL_WIN32_ZIP.sigstore.json">cosign</a> /
 <a href="CURL_WIN32_ZIP.txt">sha256</a>: SHA256_CURL_WIN32<br>
 #endif
 
@@ -77,18 +77,18 @@ SUBTITLE(Fixed URLs)
 <p>
 <a download="curl-win64-latest.zip" href="latest.cgi?p=win64-mingw.zip">curl for win64 Intel</a>
 / <a download="curl-win64-latest.zip.asc" href="latest.cgi?p=win64-mingw.zip.asc">pgp</a>
-/ <a download="curl-win64-latest.zip.sigstore" href="latest.cgi?p=win64-mingw.zip.sigstore">cosign</a>
+/ <a download="curl-win64-latest.zip.sigstore.json" href="latest.cgi?p=win64-mingw.zip.sigstore.json">cosign</a>
 / <a download="curl-win64-latest.zip.txt" href="latest.cgi?p=win64-mingw.zip.txt">sha256</a><br>
 #ifdef CURL_WIN64A_ZIP
 <a download="curl-win64a-latest.zip" href="latest.cgi?p=win64a-mingw.zip">curl for win64 ARM64</a>
 / <a download="curl-win64a-latest.zip.asc" href="latest.cgi?p=win64a-mingw.zip.asc">pgp</a>
-/ <a download="curl-win64a-latest.zip.sigstore" href="latest.cgi?p=win64a-mingw.zip.sigstore">cosign</a>
+/ <a download="curl-win64a-latest.zip.sigstore.json" href="latest.cgi?p=win64a-mingw.zip.sigstore.json">cosign</a>
 / <a download="curl-win64a-latest.zip.txt" href="latest.cgi?p=win64a-mingw.zip.txt">sha256</a><br>
 #endif
 #ifdef CURL_WIN32_ZIP
 <a download="curl-win32-latest.zip" href="latest.cgi?p=win32-mingw.zip">curl for win32 Intel</a>
 / <a download="curl-win32-latest.zip.asc" href="latest.cgi?p=win32-mingw.zip.asc">pgp</a>
-/ <a download="curl-win32-latest.zip.sigstore" href="latest.cgi?p=win32-mingw.zip.sigstore">cosign</a>
+/ <a download="curl-win32-latest.zip.sigstore.json" href="latest.cgi?p=win32-mingw.zip.sigstore.json">cosign</a>
 / <a download="curl-win32-latest.zip.txt" href="latest.cgi?p=win32-mingw.zip.txt">sha256</a><br>
 #endif
 


### PR DESCRIPTION
That seems to be the official filename suffix, though it's difficult to tell.