### PR TITLE
Add an HTTP request cheat sheet

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -197,6 +197,7 @@ PAGES = \
  bugbounty.html \
  bugs.html \
  caextract.html \
+ cheat-sheet.html \
  code-of-conduct.html \
  companies.html \
  comparison-table.html \
@@ -314,6 +315,9 @@ bugs.html: _bugs.html $(MAINPARTS) bugs.gen
 
 bugs.gen: $(DOCROOT)/BUGS.md faqparse.pl
 	$(MARKDOWN) < $< > $@
+
+cheat-sheet.html: _cheat-sheet.html $(MAINPARTS)
+	$(ACTION)
 
 bugbounty.html: _bugbounty.html $(MAINPARTS) bugbounty.gen $(ADVBOX)
 	$(ACTION)

--- a/docs/_cheat-sheet.html
+++ b/docs/_cheat-sheet.html
@@ -1,0 +1,122 @@
+#include "_doctype.html"
+<html>
+<head> <title>curl - Cheat Sheet</title>
+#include "css.t"
+<link rel="stylesheet" type="text/css" href="cheat-sheet.css">
+</head>
+
+#define CURL_DOCS
+#define CURL_URL docs/cheat-sheet.html
+
+#define TOOL_DOCS
+#include "_menu.html"
+#include "setup.t"
+
+WHERE2(Docs, "/docs/", Cheat Sheet)
+
+TITLE(curl HTTP cheat sheet)
+<div class="relatedbox">
+<b>Related:</b>
+<br><a href="manpage.html">curl man page</a>
+<br><a href="tutorial.html">Tutorial</a>
+</div>
+
+<section>
+  <h2>GET requests</h2>
+  <div class="item">
+    <h3>GET a website</h3>
+    <code>curl https://example.com</code>
+  </div>
+
+  <div class="item">
+    <h3>Follow redirects</h3>
+    <code>curl <a href="https://curl.se/docs/manpage.html#-L"><em>-L</em></a> https://example.com</code>
+  </div>
+
+  <div class="item">
+    <h3>Hide the progress bar</h3>
+    <code>curl <a href="https://curl.se/docs/manpage.html#-s"><em>-s</em></a> https://example.com</code>
+  </div>
+
+  <div class="item">
+    <h3>Output to a file</h3>
+    <code>curl <a href="https://curl.se/docs/manpage.html#-o"><em>-o</em></a> out.html https://example.com/ </code>
+  </div>
+</section>
+
+<section>
+  <h2> Set or view headers </h2>
+  <div class="item">
+    <h3>Show response headers</h3>
+    <code>curl <a href="https://curl.se/docs/manpage.html#-i"><em>-i</em></a> https://example.com</code>
+  </div>
+
+  <div class="item">
+    <h3>Make a HEAD request</h3>
+    <code>curl <a href="https://curl.se/docs/manpage.html#-I"><em>-I</em></a> https://example.com</code>
+  </div>
+
+  <div class="item">
+    <h3>Set a header</h3>
+    <code>curl https://pages.github.io
+      <span class="nobreak"><a href="https://curl.se/docs/manpage.html#-H">
+    <em>-H</em></a> "Host: raytracing.github.io"</span>
+    </code>
+  </div>
+</section>
+
+<section>
+  <h2>POST requests</h2>
+  <div class="item">
+    <h3>POST some JSON</h3>
+    <code>
+      curl -v httpbin.io/post
+      <span class="nobreak"><a href="https://curl.se/docs/manpage.html#--json"><em>--json</em></a> '{"key":"value"}'</span>
+    </code>
+  </div>
+
+  <div class="item">
+    <h3>POST JSON from a file</h3>
+    <code>
+      curl -v httpbin.io/post
+      <span class="nobreak"><a href="https://curl.se/docs/manpage.html#--json"><em>--json</em></a> @file.json</span>
+    </code>
+  </div>
+
+  <div class="item">
+    <h3>POST application/url-encoded data</h3>
+    <code>
+      curl -v httpbin.io/post
+      <span class="nobreak"><a href="https://curl.se/docs/manpage.html#--data-urlencode"><em>--data-urlencode</em></a> name=maya</span>
+      <span class="nobreak"><a href="https://curl.se/docs/manpage.html#--data-urlencode"><em>--data-urlencode</em></a> date=2024-01-01</span>
+    </code>
+  </div>
+</section>
+
+<section>
+  <h2>More</h2>
+
+  <div class="item">
+    <h3>Make a DELETE request</h3>
+    <code>curl <a href="https://curl.se/docs/manpage.html#-X"><em>-X</em></a> DELETE example.com</code>
+  </div>
+
+  <div class="item">
+    <h3>Override DNS resolution</h3>
+    <code>curl example.com <a href="https://curl.se/docs/manpage.html#--resolve"><em>--resolve</em></a> <span class="nobreak">example.com:443:23.220.75.245</span></code>
+  </div>
+
+  <div class="item">
+    <h3>Do basic authentication</h3>
+    <code>
+      curl <a href="https://curl.se/docs/manpage.html#-u"><em>-u</em></a> user:pass
+      example.com
+    </code>
+  </div>
+
+
+</section>
+
+#include "_footer.html"
+</body>
+</html>

--- a/docs/_menu.html
+++ b/docs/_menu.html
@@ -71,6 +71,7 @@ VLINK(/docs/, Docs Overview, Documentation Overview)
     <a href="/docs/httpscripting.html">HTTP Scripting</a>
     <a href="/docs/mk-ca-bundle.html">mk-ca-bundle</a>
     <a href="/docs/tutorial.html">Tutorial</a>
+    <a href="/docs/cheat-sheet.html">Cheat Sheet</a>
     <a href="optionswhen.html">When options were added</a>
   </div>
 </div>

--- a/docs/cheat-sheet.css
+++ b/docs/cheat-sheet.css
@@ -1,0 +1,119 @@
+:root {
+  --darkblue: #093754;
+  --darkgreen: #0c544c;
+}
+
+body {
+  color: black;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: white;
+  border-radius: 16px;
+}
+
+.item {
+  background: white;
+  padding: 14px 16px;
+  border-radius: 8px;
+  border: 1px solid rgba(9, 55, 84, 0.15);
+  display: flex;
+  font-size: 1rem;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: 0 1px 4px rgba(9, 55, 84, 0.08);
+  transition: all 0.3s ease;
+
+  p {
+    font-size: 1rem;
+    margin: 0 8px;
+  }
+
+  h3 {
+    line-height: 1.2em;
+    font-size: 1.1rem;
+    margin: 0;
+    margin-bottom: .4rem;
+    font-weight: 600;
+    color: var(--darkblue);
+  }
+
+
+  label {
+    display: block;
+    margin-top: 10px;
+  }
+
+  code {
+    color: var(--darkgreen);
+    background: #f8fafc;
+    font-family: 'SF Mono', 'Monaco', 'Cascadia Code', 'Courier New', monospace;
+    margin-bottom: 0;
+    line-height: 1.4rem;
+    padding: 10px 12px;
+    border-radius: 6px;
+    border: 1px solid rgba(9, 55, 84, 0.15);
+    font-size: 1rem;
+    text-indent: -1.5em;
+    padding-left: calc(12px + 1.5em);
+  }
+
+  em {
+    padding: .2rem .4rem;
+    background: var(--darkgreen);
+    color: white;
+    border-radius: 4px;
+    font-weight: 600;
+    font-style: normal;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+  }
+
+  a em {
+    color: white;
+    text-decoration: none;
+  }
+
+  a:hover em {
+    background: var(--darkblue);
+    text-decoration: underline;
+  }
+
+  h3 code {
+    padding: 0;
+    background: transparent;
+  }
+
+  .or {
+    font-weight: 700;
+    font-size: 0.8em;
+    display: block;
+    margin-left: 30px;
+    font-family: sans-serif;
+  }
+
+  .nobreak {
+    white-space: nowrap;
+  }
+}
+
+section {
+  margin-bottom: 24px;
+  width: 100%;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr 1fr;
+
+  @media (max-width: 700px) {
+    & {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+  }
+
+  h2 {
+    grid-column: 1/3;
+    margin: 0;
+  }
+
+}


### PR DESCRIPTION
I'm a big fan of using curl to make HTTP requests, but I'm always forgetting how to do basic things in curl, like "how do I make a POST request with JSON again?". So I was thinking it could be useful if curl had an official cheat sheet. I know there's a [tutorial](https://curl.se/docs/tutorial.html), but it's quite long and personally I only use an extremely minimal subset of curl's functionality.

This is a pretty rough draft but I wanted to see if there's interest before getting into the details. I linked each option to the appropriate place in the man page.

Here's what it looks like visually right now. 
<img width="715" height="650" alt="image" src="https://github.com/user-attachments/assets/90d8e2d8-e065-4a0f-b071-9bbe9367003f" />

some todos:

- [ ] not sure about the name yet (maybe it should be `http-cheat-sheet.html`?). I feel like it's useful to have a cheat sheet just for doing HTTP(S) requests in curl even though curl does much more.
- [ ] Probably the CSS should be simplified or look a little closer to the curl website's aesthetic
- [ ] The CSS uses nested selectors, that needs to be fixed because not all browsers support nested selectors yet
- [ ] Maybe mention how to set cookies?