### PR TITLE
GHA: fix shellcheck SC2046

### DIFF
--- a/.github/scripts/badwords.pl
+++ b/.github/scripts/badwords.pl
@@ -9,6 +9,12 @@
 # If separator is ':', the check is done case insensitively.
 #
 
+use strict;
+use warnings;
+
+my %alt;
+my %exactcase;
+
 my %wl;
 if($ARGV[0] eq "-w") {
     shift @ARGV;
@@ -27,7 +33,7 @@ if($ARGV[0] eq "-w") {
     close(W);
 }
 
-my $w;
+my @w;
 while(<STDIN>) {
     chomp;
     if($_ =~ /^#/) {
@@ -43,7 +49,7 @@ while(<STDIN>) {
     }
 }
 
-my $errors;
+my $errors = 0;
 
 sub file {
     my ($f) = @_;
@@ -86,9 +92,11 @@ sub file {
     close(F);
 }
 
-my @files = @ARGV;
-
-foreach my $each (@files) {
+my @filemasks = @ARGV;
+open(my $git_ls_files, '-|', 'git', 'ls-files', '--', @filemasks) or die "Failed running git ls-files: $!";
+while(my $each = <$git_ls_files>) {
+    chomp $each;
     file($each);
 }
+close $git_ls_files;
 exit $errors;

--- a/.github/scripts/codespell.sh
+++ b/.github/scripts/codespell.sh
@@ -7,7 +7,7 @@ set -eu
 
 cd "$(dirname "${0}")"/../..
 
-# shellcheck disable=SC2046
+git ls-files -z | xargs -0 -r \
 codespell \
   --skip '.github/scripts/pyspelling.words' \
   --skip '.github/scripts/typos.toml' \
@@ -22,4 +22,4 @@ codespell \
   --skip 'rfc/cookie_spec.html' \
   --skip 'rfc/ntlm.html' \
   --ignore-words '.github/scripts/codespell-ignore.words' \
-  $(git ls-files)
+  --

--- a/.github/workflows/badwords.yml
+++ b/.github/workflows/badwords.yml
@@ -31,4 +31,4 @@ jobs:
           persist-credentials: false
 
       - name: check
-        run: .github/scripts/badwords.pl -w .github/scripts/badwords.ok < .github/scripts/badwords.txt docs/*.md '*html'
+        run: .github/scripts/badwords.pl -w .github/scripts/badwords.ok 'docs/*.md' < .github/scripts/badwords.txt


### PR DESCRIPTION
Also:
- sync badwords.pl a bit with curl/curl.
- note that `*html` was not checked by badwords.pl because passing it as
  literal, and there is a lot of fallouts when enabled.
  Ref: 08d4f2cf8012929e53756e49621066b7f26b47af
