### PR TITLE
CVE-2025-10966: Bump fixed version to 8.17.0

### DIFF
--- a/docs/CVE-2025-10966.md
+++ b/docs/CVE-2025-10966.md
@@ -48,7 +48,7 @@ AFFECTED VERSIONS
 -----------------
 
 - Affected versions: curl 7.69.0 to and including 8.16.0
-- Not affected versions: curl < 7.69.0 and >= 8.16.0
+- Not affected versions: curl < 7.69.0 and >= 8.17.0
 - Introduced-in: https://github.com/curl/curl/commit/6773c7ca65cf2183295e56
 
 libcurl is used by many applications, but not always advertised as such!


### PR DESCRIPTION
Avoid overlapping affected/not-affected versions.

wolfSSH backend was dropped in 8.17.0.

---

While reading the CVE as part of `pkgsrc-security@` work I had noticed that in the list the 8.16.0 release was mentioned while this vulnerability was actually fixed in 8.17.0 by dropping the wolfSSH backend and as all other part of the CVEs states.

Please also note that I have also double-checked the CVE JSON in [CVE List V5](https://github.com/CVEProject/cvelistV5) and it is correct (`containers.cna.affected` lists as up to including 8.16.0 so 8.17.0 is unaffected) so no changes are needed there.

---

Thank you!
