### PR TITLE
mk-wcurl-adv-template: drop the json link from related box

### DIFF
--- a/docs/mk-wcurl-adv-template.pl
+++ b/docs/mk-wcurl-adv-template.pl
@@ -21,12 +21,12 @@ my $markdown = join("", @md);
 
         print <<TEMPLATE
 #include "_doctype.html"
-#define FLAWCVE $cve
+#define FLAW $cve
 $dissue
 $daward
 
 <html>
-<head> <title>wcurl - FLAWCVE</title>
+<head> <title>wcurl - FLAW</title>
 #include "css.t"
 #include "manpage.t"
 <style>
@@ -51,11 +51,11 @@ code {
 #include "setup.t"
 #include "advisory.t"
 
-WHERE3(Docs, "/docs/", curl CVEs, "/docs/security.html", FLAWCVE)
+WHERE3(Docs, "/docs/", curl CVEs, "/docs/security.html", FLAW)
 
 #include "adv-related-box.inc"
 
-<h2>FLAWCVE</h2>
+<h2>FLAW</h2>
 $markdown
 #include "_footer.html"
 </body> </html>


### PR DESCRIPTION
There is JSON generated for this CVE because the script making those is only made for curl CVEs.

Ref: #503