### PR TITLE
mktlstable: Use correct capitalization for rustls

### DIFF
--- a/libcurl/c/mktlstable
+++ b/libcurl/c/mktlstable
@@ -29,7 +29,7 @@ my %knowntls = (
     'wolfSSL' => 3,
     'mbedTLS' => 4,
     'Schannel' => 5,
-    'Rustls' => 6,
+    'rustls' => 6,
     );
 
 sub single {


### PR DESCRIPTION
This is what is used in the actual md documentation