### PR TITLE
mkexam: CSSify the enscript output

### DIFF
--- a/libcurl/c/_example-templ.html
+++ b/libcurl/c/_example-templ.html
@@ -2,6 +2,7 @@
 <html>
 <head> <title>libcurl example - %cfile%</title>
 #include "css.t"
+<link rel="stylesheet" type="text/css" href="example.css">
 </head>
 
 #define LIBCURL_EXAMPLE

--- a/libcurl/c/example.css
+++ b/libcurl/c/example.css
@@ -1,0 +1,35 @@
+
+span.comment {
+    color: #B22222;
+    font-style: italic;
+}
+span.cpp {
+    color: #5F9EA0;
+}
+span.type {
+    color: #228B22;
+    font-weight: bold;
+}
+span.expr {
+    color: #A020F0;
+    font-weight: bold;
+}
+span.string {
+    color: #BC8F8F;
+}
+span.function {
+    color: #a0a000;
+}
+
+/* DARK MODE PROPERTIES */
+/* These will override all settings above */
+@media (prefers-color-scheme: dark) {
+
+  span.comment {
+      color: #ff8080;
+      font-style: italic;
+  }
+  span.function {
+      color: #ffff00;
+  }
+}

--- a/libcurl/c/mkexam.pl
+++ b/libcurl/c/mkexam.pl
@@ -47,6 +47,15 @@ for my $f (@samps) {
     # now run enscript and extract the PRE part and linkify some of the libcurl
     # stuff
     #
+
+    # enscript generates hard-coded font colors. Replace each such <font>
+    # instruction with a dedicated <span> tag.
+    my %color2tag = ('B22222' => 'comment',
+                     '5F9EA0' => 'cpp',
+                     '228B22' => 'type',
+                     'A020F0' => 'expr',
+                     'BC8F8F' => 'string',
+                     '0000FF' => 'function');
     open(ET, ">$encfile");
     open(CMD, "$cmd|");
     my $show=0;
@@ -57,6 +66,13 @@ for my $f (@samps) {
 
         if($show) {
             my $l=$_;
+
+            $l =~ s/\<FONT COLOR=\"\#([0-9A-F]+)\"\>/sprintf "<span class=\"".$color2tag{$1}."\">";/ge;
+            $l =~ s:\</FONT>:</span>:g;
+            $l =~ s:<B>::g;
+            $l =~ s:</B>::g;
+            $l =~ s:<I>::g;
+            $l =~ s:</I>::g;
 
             # find curl_ function invokes
             if($l =~ /^(.*)(curl_[a-z_]*)( *\(.*)/) {


### PR DESCRIPTION
mkexam.pl now converts the enscript output from using hard-coded font color values to instead use <span> with specific class names for different code sections.

example.css is a new CSS file with the styles for the examples, with some minor ajustments to work better in dark mode: primarily the comment style is now using a lighter red.