### PR TITLE
typos: exclude `mk-sponsors.pl`

### DIFF
--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -15,6 +15,7 @@ extend-exclude = [
   ".github/scripts/pyspelling.words",
   "dev/explainopts.t",
   "docs/_companies.html",
+  "mk-sponsors.pl",
   "_changes.html",
   "rfc/*.txt",
   "rfc/cookie_spec.html",


### PR DESCRIPTION
Silencing:
```
typos-cli 1.40.0
error: `conet` should be `connect`
   ╭▸ mk-sponsors.pl:27:6
   │
27 │     'conet-gmbh' => '[none]', # no logo provided
   ╰╴     ━━━━━
Error: Process completed with exit code 2.
```
https://github.com/curl/curl-www/actions/runs/20216152359/job/58029393959?pr=518

Bug: https://github.com/curl/curl-www/pull/518#issuecomment-3655105880
