### PR TITLE
docs/_ssl-compared.html: fixups

### DIFF
--- a/docs/_ssl-compared.html
+++ b/docs/_ssl-compared.html
@@ -102,7 +102,7 @@ to use.
   NEWCOL <a href="https://www.openssl.org/">OpenSSL Project</a> ENDCOL
   NEWCOL <a href="https://www.gnu.org/">Free Software Foundation</a> ENDCOL
   NEWCOL <a href="https://www.wolfssl.com/">wolfSSL</a> ENDCOL
-  NEWCOL <a href="https://tls.mbed.org/">mbed TLS</a> ENDCOL
+  NEWCOL <a href="https://tls.mbed.org/">mbedTLS</a> ENDCOL
   NEWCOL <a href="https://www.microsoft.com/">Microsoft Corporation</a> ENDCOL
   NEWCOL Open Source team ENDCOL
  ENDLINE


### PR DESCRIPTION
- wolfSSL is GPLv3 now
- remove NSS mentions
- fix P8 reference
- drop outdated license reference

Reported-by: Fabian Keil