### PR TITLE
.htaccess: drop old hostnames from Content-Security-Policy

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -120,7 +120,7 @@ AddType application/x-tar .tar
 AddType application/x-pem-file .pem
 
 Header set X-Content-Type-Options: "nosniff"
-Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se curl.se; style-src 'unsafe-inline' 'self' curl.haxx.se www.curl.se curl.se; require-trusted-types-for 'script';"
+Header set Content-Security-Policy: "default-src 'self' curl.se; style-src 'unsafe-inline' 'self' curl.se; require-trusted-types-for 'script';"
 
 # Google Custom Search requires unsafe-eval & unsafe-inline in the CSP which
 # knocks a giant hole in the protection a CSP provides. Therefore, only use
@@ -131,7 +131,7 @@ Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se
 # https://support.google.com/programmable-search/thread/60663049?hl=en
 # The hash is for the inline script in sitesearch.t
 <FilesMatch "^search\.html$|^list\.cgi$">
-Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se curl.se cse.google.com www.google.com www.googleapis.com clients1.google.com; style-src 'unsafe-inline' 'self' curl.haxx.se www.curl.se curl.se www.google.com; script-src 'unsafe-eval' 'self' curl.se cse.google.com www.google.com clients1.google.com 'sha256-n9QfETfN26toA8vPrDtfLIC9jm4B8HE2KsS/pOkgPJ4=';"
+Header set Content-Security-Policy: "default-src 'self' curl.se cse.google.com www.google.com www.googleapis.com clients1.google.com; style-src 'unsafe-inline' 'self' curl.se www.google.com; script-src 'unsafe-eval' 'self' curl.se cse.google.com www.google.com clients1.google.com 'sha256-n9QfETfN26toA8vPrDtfLIC9jm4B8HE2KsS/pOkgPJ4=';"
 </FilesMatch>
 Header always append X-Frame-Options SAMEORIGIN
 


### PR DESCRIPTION
We never actually provide the site using curl.haxx.se or www.haxx.se - they redirect to curl.se