### PR TITLE
GHA: migrate 2 linter jobs to arm64

### DIFF
--- a/.github/workflows/badwords.yml
+++ b/.github/workflows/badwords.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
   badwords:
     name: 'badwords'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -21,7 +21,7 @@ permissions: {}
 jobs:
   codespell:
     name: 'codespell'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:


### PR DESCRIPTION
For efficiency and a slightly faster badwords check.
