### PR TITLE
windows: add `minisign` signature links

### DIFF
--- a/windows/_index.html
+++ b/windows/_index.html
@@ -77,20 +77,20 @@ SUBTITLE(Fixed URLs)
 <p>
 <a download="curl-win64-latest.zip" href="latest.cgi?p=win64-mingw.zip">curl for win64 Intel</a>
 / <a download="curl-win64-latest.zip.asc" href="latest.cgi?p=win64-mingw.zip.asc">pgp</a>
-/ <a download="curl-win64-latest.zip.minisign" href="latest.cgi?p=win64-mingw.zip.minisign">cosign</a>
+/ <a download="curl-win64-latest.zip.minisign" href="latest.cgi?p=win64-mingw.zip.minisign">minisign</a>
 / <a download="curl-win64-latest.zip.sigstore" href="latest.cgi?p=win64-mingw.zip.sigstore">cosign</a>
 / <a download="curl-win64-latest.zip.txt" href="latest.cgi?p=win64-mingw.zip.txt">sha256</a><br>
 #ifdef CURL_WIN64A_ZIP
 <a download="curl-win64a-latest.zip" href="latest.cgi?p=win64a-mingw.zip">curl for win64 ARM64</a>
 / <a download="curl-win64a-latest.zip.asc" href="latest.cgi?p=win64a-mingw.zip.asc">pgp</a>
-/ <a download="curl-win64a-latest.zip.minisign" href="latest.cgi?p=win64a-mingw.zip.minisign">cosign</a>
+/ <a download="curl-win64a-latest.zip.minisign" href="latest.cgi?p=win64a-mingw.zip.minisign">minisign</a>
 / <a download="curl-win64a-latest.zip.sigstore" href="latest.cgi?p=win64a-mingw.zip.sigstore">cosign</a>
 / <a download="curl-win64a-latest.zip.txt" href="latest.cgi?p=win64a-mingw.zip.txt">sha256</a><br>
 #endif
 #ifdef CURL_WIN32_ZIP
 <a download="curl-win32-latest.zip" href="latest.cgi?p=win32-mingw.zip">curl for win32 Intel</a>
 / <a download="curl-win32-latest.zip.asc" href="latest.cgi?p=win32-mingw.zip.asc">pgp</a>
-/ <a download="curl-win32-latest.zip.minisign" href="latest.cgi?p=win32-mingw.zip.minisign">cosign</a>
+/ <a download="curl-win32-latest.zip.minisign" href="latest.cgi?p=win32-mingw.zip.minisign">minisign</a>
 / <a download="curl-win32-latest.zip.sigstore" href="latest.cgi?p=win32-mingw.zip.sigstore">cosign</a>
 / <a download="curl-win32-latest.zip.txt" href="latest.cgi?p=win32-mingw.zip.txt">sha256</a><br>
 #endif


### PR DESCRIPTION
They are tiny, secure, simple, and offline.

Ref: https://github.com/curl/curl-for-win/commit/bd891c2ab9825a5aa1e379f7abe2176f7868a332
