### PR TITLE
Update advisory information about wcurl CVE-2025-11563

### DIFF
--- a/docs/CVE-2025-11563.md
+++ b/docs/CVE-2025-11563.md
@@ -26,10 +26,10 @@ Severity: Moderate
 AFFECTED VERSIONS
 -----------------
 
-- Affected versions: wcurl shipped with curl 8.14.0 to and including 8.16.0
-- Affected versions: wcurl 2024.12.08 to and including 2025.09.27
-- Not affected versions: wcurl shipped with curl < 8.14.0 and >= 8.17.0
-- Not affected versions: wcurl < 2024.12.08 and >= 2025.11.04
+- Affected versions: wcurl shipped with curl 8.14.0 to and including 8.17.0
+- Affected versions: wcurl 2024.12.08 to and including 2025.11.04
+- Not affected versions: wcurl shipped with curl < 8.14.0 and >= 8.18.0
+- Not affected versions: wcurl < 2024.12.08 and >= 2025.11.09
 - Introduced-in: https://github.com/curl/wcurl/commit/e01d578582a23695ee3cec08
 - Introduced-in: https://github.com/curl/curl/commit/23bed347b3892277938259
 
@@ -38,17 +38,17 @@ This flaw only affects the wcurl command line tool.
 SOLUTION
 ------------
 
-Starting in wcurl 2025.11.04 (shipped with curl 8.17.0), this mistake is
+Starting in wcurl 2025.11.09 (shipped with curl 8.18.0), this mistake is
 fixed.
 
-- Fixed-in: https://github.com/curl/wcurl/commit/524f7e733237cd26553dfd
-- Fixed-in: https://github.com/curl/curl/commit/fb0c014e30e5f4de7aa0d566c
+- Fixed-in: https://github.com/curl/wcurl/commit/65546bae0164a97d89d42176e366d9c7c7796261
+- Fixed-in: https://github.com/curl/curl/commit/79d3e1d7d44dda65fdc303a53a44109583135b12
 
 RECOMMENDATIONS
 --------------
 
- A - Upgrade wcurl to the one shipped in curl version 8.17.0, wcurl to version
-     2025.11.04
+ A - Upgrade wcurl to the one shipped in curl version 8.18.0, wcurl to version
+     2025.11.09
 
  B - Apply the patch to your local wcurl version
 
@@ -62,10 +62,9 @@ TIMELINE
 This issue was reported to the curl project on October 6, 2025. We contacted
 distros@openwall on October 30.
 
-wcurl 2025.11.04 was released on November 4 2025, coordinated with the
-publication of this advisory.
+wcurl 2025.11.09 was released on November 9 2025.
 
-curl 8.17.0 was released on November 5 2025.
+curl 8.18.0 was released on January 7 2026 around 07:00 UTC.
 
 The curl security team is not aware of any active exploits using this
 vulnerability.
@@ -76,5 +75,6 @@ CREDITS
 - Reported-by: Stanislav Fort (Aisle Research)
 - Patched-by: Samuel Henrique
 - Patched-by: Sergio Durigan Junior
+- Patched-by: Xi Ruoyao
 
 Thanks a lot!


### PR DESCRIPTION
Let me know if I should have added anything in a changelog-like field to describe the changes.

I wasn't sure if the json should be submitted anywhere since the repo doesn't store any, but here's my try at writing one:

```json
{
  "schema_version": "1.5.0",
  "id": "CURL-CVE-2025-11563",
  "aliases": [
    "CVE-2025-11563"
  ],
  "summary": "wcurl path traversal with percent-encoded slashes",
  "modified": "2026-01-07T07:59:34.00Z",
  "database_specific": {
    "package": "curl",
    "affects": "wcurl",
    "URL": "https://curl.se/docs/CVE-2025-11563.json",
    "www": "https://curl.se/docs/CVE-2025-11563.html",
    "CWE": {
      "id": "CWE-35",
      "desc": "Path Traversal"
    },
    "last_affected": "8.17.0",
    "severity": "Moderate"
  },
  "published": "2026-01-07T08:00:00.00Z",
  "affected": [
    {
      "ranges": [
        {
          "type": "SEMVER",
          "events": [
            {"introduced": "8.14.0"},
            {"fixed": "8.18.0"}
          ]
        },
        {
          "type": "GIT",
          "repo": "https://github.com/curl/curl.git",
          "events": [
            {"introduced": "23bed347b3892277938259"},
            {"fixed": "79d3e1d7d44dda65fdc303a53a44109583135b12"}
          ]
        },
        {
          "type": "GIT",
          "repo": "https://github.com/curl/wcurl.git",
          "events": [
            {"introduced": "e01d578582a23695ee3cec08"},
            {"fixed": "65546bae0164a97d89d42176e366d9c7c7796261"}
          ]
        }
      ],
      "versions": [
        "8.17.0", "8.16.0", "8.15.0", "8.14.1", "8.14.0"
      ]
    }
  ],
  "credits": [
    {
      "name": "Stanislav Fort (Aisle Research)",
      "type": "FINDER"
    },
    {
      "name": "Samuel Henrique",
      "type": "REMEDIATION_DEVELOPER"
    },
    {
      "name": "Sergio Durigan Junior",
      "type": "REMEDIATION_DEVELOPER"
    },
    {
      "name": "Xi Ruoyao",
      "type": "REMEDIATION_DEVELOPER"
    }
  ],
  "details": "URLs containing percent-encoded slashes (`/` or `\\`) can trick wcurl into\nsaving the output file outside of the current directory without the user\nexplicitly asking for it.\n\nThis flaw only affects the wcurl command line tool."
}
```

cc @xquery, I've copied "modified" and "published" values from CVE-2025-15224, but I assume you will actually replace them with something else.

Related to https://github.com/curl/curl-www/issues/503.