### PR TITLE
CVE-2025-11563.json: add

### DIFF
--- a/docs/CVE-2025-11563.json.in
+++ b/docs/CVE-2025-11563.json.in
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1.5.0",
+  "id": "CURL-CVE-2025-11563",
+  "aliases": [
+    "CVE-2025-11563"
+  ],
+  "summary": "wcurl path traversal with percent-encoded slashes",
+  "modified": "2026-01-07T07:59:34.00Z",
+  "database_specific": {
+    "package": "curl",
+    "affects": "wcurl",
+    "URL": "https://curl.se/docs/CVE-2025-11563.json",
+    "www": "https://curl.se/docs/CVE-2025-11563.html",
+    "CWE": {
+      "id": "CWE-35",
+      "desc": "Path Traversal"
+    },
+    "last_affected": "8.17.0",
+    "severity": "Moderate"
+  },
+  "published": "2026-01-07T08:00:00.00Z",
+  "affected": [
+    {
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {"introduced": "8.14.0"},
+            {"fixed": "8.18.0"}
+          ]
+        },
+        {
+          "type": "GIT",
+          "repo": "https://github.com/curl/curl.git",
+          "events": [
+            {"introduced": "23bed347b3892277938259"},
+            {"fixed": "79d3e1d7d44dda65fdc303a53a44109583135b12"}
+          ]
+        },
+        {
+          "type": "GIT",
+          "repo": "https://github.com/curl/wcurl.git",
+          "events": [
+            {"introduced": "e01d578582a23695ee3cec08"},
+            {"fixed": "65546bae0164a97d89d42176e366d9c7c7796261"}
+          ]
+        }
+      ],
+      "versions": [
+        "8.17.0", "8.16.0", "8.15.0", "8.14.1", "8.14.0"
+      ]
+    }
+  ],
+  "credits": [
+    {
+      "name": "Stanislav Fort (Aisle Research)",
+      "type": "FINDER"
+    },
+    {
+      "name": "Samuel Henrique",
+      "type": "REMEDIATION_DEVELOPER"
+    },
+    {
+      "name": "Sergio Durigan Junior",
+      "type": "REMEDIATION_DEVELOPER"
+    },
+    {
+      "name": "Xi Ruoyao",
+      "type": "REMEDIATION_DEVELOPER"
+    }
+  ],
+  "details": "URLs containing percent-encoded slashes (`/` or `\\`) can trick wcurl into\nsaving the output file outside of the current directory without the user\nexplicitly asking for it.\n\nThis flaw only affects the wcurl command line tool."
+}

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,6 +17,9 @@ MAN2HTML = roffit --man=$(SRCROOT)/docs/libcurl=../libcurl/c --bare
 WCURLCVE = \
  CVE-2025-11563.html
 
+WCURLJSON = \
+ CVE-2025-11563.json
+
 CVELIST = \
  CVE-2000-0973.html \
  CVE-2003-1605.html \
@@ -203,6 +206,7 @@ CVELIST = \
 PAGES = \
  $(CVELIST) \
  $(WCURLCVE) \
+ $(WCURLJSON) \
  alt-svc.html \
  audits.html \
  bugbounty.html \
@@ -564,3 +568,6 @@ releases.csv: $(ROOT)/_changes.html ./relinfo.pl vuln.pm allvulns.gen
 
 thename.html: _thename.html $(MAINPARTS)
 	$(ACTION)
+
+$(WCURLJSON): $(WCURLJSON).in
+	ln -sf $(WCURLJSON).in $(WCURLJSON)


### PR DESCRIPTION
The other json files for plain curl/libcurl issues are generated by scripts but this is a wcurl issue which does not have its meta-data readily available the same way so this file is "hard-coded".

Ref: #549

/cc  @samueloph @xquery 