### PR TITLE
windows: recognize standard sha256sum line prefix

### DIFF
--- a/windows/mkfiles.pl
+++ b/windows/mkfiles.pl
@@ -84,7 +84,7 @@ sub gethashes {
     my ($dir)=@_; # where the download files are
     open(H, "$dir/hashes.txt") || return;
     while(<H>) {
-        if($_ =~ /^SHA2-256\(([^)]*)\)= (.*)/) {
+        if($_ =~ /^SHA256\(([^)]*)\)= (.*)/) {
             my ($file, $hash)=($1, $2);
             if($file =~ /^([^-]*)-.*-([^-]*)-mingw.zip/) {
                 my ($dep, $arch) = ($1, $2);


### PR DESCRIPTION
curl-for-win switched from `openssl dgst -sha256` to `sha256sum`.
Switch back to recognize the standard format emitted by the latter.

Ref: https://github.com/curl/curl-for-win/commit/3f56ef92bd6a419296aab894eebe259e0e82aeda
