### PR TITLE
windows: recognize standard sha256sum line prefix (cont.)

### DIFF
--- a/windows/mkfiles.pl
+++ b/windows/mkfiles.pl
@@ -84,7 +84,7 @@ sub gethashes {
     my ($dir)=@_; # where the download files are
     open(H, "$dir/hashes.txt") || return;
     while(<H>) {
-        if($_ =~ /^SHA256\(([^)]*)\)= (.*)/) {
+        if($_ =~ /^SHA256 *\(([^)]*)\) *= (.*)/) {
             my ($file, $hash)=($1, $2);
             if($file =~ /^([^-]*)-.*-([^-]*)-mingw.zip/) {
                 my ($dep, $arch) = ($1, $2);


### PR DESCRIPTION
Account for spaces.

Previous, OpenSSL-specific format:
```
SHA2-256(curl-8.18.0_4-win64-mingw.zip)= bc52b55b4142e8f96a3697a514be5e2f3c7e0842ad73bce7ec58dc4c374764d9
```
New, standard format:
```
SHA256 (curl-8.18.0_5-win64-mingw.zip) = dd9f7c7ad689f5b1c590a2d8c03e3a0a3664a5ed3ce7a8fa2d379f3e3188fe3e
```

Follow-up to c1bb0f25ba2225695e8eb2a813fe1b4611463ed4
