### PR TITLE
index: tweak the top text

### DIFF
--- a/_index.html
+++ b/_index.html
@@ -77,13 +77,8 @@ td {
 <center><img src="https://curl.se/logo/curl-logo.svg" alt="curl logo" style="width:90%; padding-top: 8px;">
 </center>
 
-<p>
-<hr>
-<p style="font-size: 160%; text-align: center;">
-  <b>command line tool and
-library</b>
-  <br>for transferring data with URLs
-  <br>(since 1998)</p>
+<p style="font-size: 160%; text-align: center; margin: auto; width: 70%; padding-top: 20px;">
+  <b>command line tool and library</b> for transferring data with URLs
 
 <div style="float: right; max-width: 10em; margin-left: 40px;">
   <div class="sponsors">


### PR DESCRIPTION
- drop the `<br>` in the text
- make it use 70% width
- drop the `<hr>` between the logo and the text
- add a 20px padding above the text instead
- drop "since 1998"