### PR TITLE
windows: tidy up CPU names

### DIFF
--- a/windows/_index.html
+++ b/windows/_index.html
@@ -41,8 +41,8 @@ TITLE(curl DEP_CURL for Windows)
  <b>Supported Windows versions</b>: Vista, 7, 8, 10, 11
 
 <p class="windl">
-  <a href="CURL_WIN64_ZIP"><img src="../pix/GS-Download-icon.svg" alt="Download curl for 64-bit Intel" width="90" height="90" style="float:left;"></a>
-  <a href="CURL_WIN64_ZIP" class="windl">curl for 64-bit Intel</a> <br>
+  <a href="CURL_WIN64_ZIP"><img src="../pix/GS-Download-icon.svg" alt="Download curl for x64" width="90" height="90" style="float:left;"></a>
+  <a href="CURL_WIN64_ZIP" class="windl">curl for x64</a> <br>
 Size: CURL_WIN64_ZIP_SIZE<br>
 <a href="CURL_WIN64_ZIP.asc">pgp</a> /
 <a href="CURL_WIN64_ZIP.minisig">minisign</a> /
@@ -52,8 +52,8 @@ Size: CURL_WIN64_ZIP_SIZE<br>
 
 #ifdef CURL_WIN64A_ZIP
 <p class="windl">
-  <a href="CURL_WIN64A_ZIP"><img src="../pix/GS-Download-icon.svg" alt="Download curl for 64-bit ARM64" width="90" height="90" style="float:left;"></a>
-  <a href="CURL_WIN64A_ZIP" class="windl">curl for 64-bit ARM64</a> <br>
+  <a href="CURL_WIN64A_ZIP"><img src="../pix/GS-Download-icon.svg" alt="Download curl for ARM64" width="90" height="90" style="float:left;"></a>
+  <a href="CURL_WIN64A_ZIP" class="windl">curl for ARM64</a> <br>
 Size: CURL_WIN64A_ZIP_SIZE<br>
 <a href="CURL_WIN64A_ZIP.asc">pgp</a> /
 <a href="CURL_WIN64A_ZIP.minisig">minisign</a> /
@@ -66,14 +66,14 @@ SUBTITLE(Fixed URLs)
 <p>
   These links automatically provide the latest curl package:
 <p>
-<a download="curl-win64-latest.zip" href="latest.cgi?p=win64-mingw.zip">curl for 64-bit Intel</a>
+<a download="curl-win64-latest.zip" href="latest.cgi?p=win64-mingw.zip">curl for x64</a>
 / <a download="curl-win64-latest.zip.asc" href="latest.cgi?p=win64-mingw.zip.asc">pgp</a>
 / <a download="curl-win64-latest.zip.minisig" href="latest.cgi?p=win64-mingw.zip.minisig">minisign</a>
 / <a download="curl-win64-latest.zip.sigstore" href="latest.cgi?p=win64-mingw.zip.sigstore">cosign</a>
 / <a download="curl-win64-latest.zip.sig" href="latest.cgi?p=win64-mingw.zip.sig">SSH</a>
 / <a download="curl-win64-latest.zip.txt" href="latest.cgi?p=win64-mingw.zip.txt">sha256</a><br>
 #ifdef CURL_WIN64A_ZIP
-<a download="curl-win64a-latest.zip" href="latest.cgi?p=win64a-mingw.zip">curl for 64-bit ARM64</a>
+<a download="curl-win64a-latest.zip" href="latest.cgi?p=win64a-mingw.zip">curl for ARM64</a>
 / <a download="curl-win64a-latest.zip.asc" href="latest.cgi?p=win64a-mingw.zip.asc">pgp</a>
 / <a download="curl-win64a-latest.zip.minisig" href="latest.cgi?p=win64a-mingw.zip.minisig">minisign</a>
 / <a download="curl-win64a-latest.zip.sigstore" href="latest.cgi?p=win64a-mingw.zip.sigstore">cosign</a>


### PR DESCRIPTION
- 64-bit Intel -> x64 to also include AMD
- 64-bit ARM64 -> ARM64 to avoid repetition
