### PR TITLE
Add text wrapping to code blocks

### DIFF
--- a/curl.css
+++ b/curl.css
@@ -103,6 +103,7 @@ td.newsdate {
 
 code {
   color: #2020a0;
+  text-wrap: wrap;
 }
 
 .warning {


### PR DESCRIPTION
Presently code blocks with long lines overflow off the screen and horizontal scrolling is blocked.

# Before

Code overflows off edge, cannot scroll

<img width="1427" height="467" alt="Screenshot 2026-03-05 at 13 55 07" src="https://github.com/user-attachments/assets/0649599c-7205-4ff5-8217-4b1d5d9e94b2" />

# After

Code wraps

<img width="1102" height="534" alt="Screenshot 2026-03-05 at 13 55 15" src="https://github.com/user-attachments/assets/f62b144a-0fa3-4a11-92ac-c2279ccc44b9" />
