### PR TITLE
curlopt2href.pl: improve the version number link regex

### DIFF
--- a/libcurl/c/curlopt2href.pl
+++ b/libcurl/c/curlopt2href.pl
@@ -16,7 +16,7 @@ while(<STDIN>) {
     $_ =~ s/([^\">\/]|^)(curl_(url|ws|pushheader|global|version|slist|share|mime|easy|curl|multi)_[a-z_]*)(\()/$1<a href="$2.html">$2<\/a>$4/g;
     $_ =~ s/([^\">\/]|^)(curl_(url|getenv|strequal|strnequal|getdate|formfree|formadd|formget|free|escape|unescape|version|mprintf))(\()/$1<a href="$2.html">$2<\/a>$4/g;
     $_ =~ s/([^\">\/]|^)(curl_(mfprintf|msprintf|msnprintf|mvprintf|mvfprintf|mvsprintf|mvsnprintf|maprintf|mvaprintf))(\()/$1<a href="curl_mprintf.html">$2<\/a>$4/g;
-    $_ =~ s/\b([78]\.\d+[.0-9]*[0-9])/<a href="\/ch\/$1.html">$1<\/a>$2/g;
+    $_ =~ s/\b([78]\.\d+[.0-9]*[0-9])/<a href="\/ch\/$1.html">$1<\/a>/g;
     print $_;
 }
 


### PR DESCRIPTION
Insist on a word boundary before the version number for it to match.

Fixes #566
Reported-by: Michael Kaufmann