### PR TITLE
curl.css: consistent code block styling

### DIFF
--- a/curl.css
+++ b/curl.css
@@ -636,7 +636,6 @@ p.level1 {
   }
 
   div.sourceCode {
-    /* background-color: #313131 !important; */
     background-color: unset !important;
   }
   code, pre {

--- a/curl.css
+++ b/curl.css
@@ -106,6 +106,18 @@ code {
   text-wrap: wrap;
 }
 
+pre {
+  min-width: fit-content;
+  padding-left: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f0f0f0;
+}
+
+pre code {
+  display: inline-block;
+}
+
 .warning {
   font-size: 14pt;
   color: #000000;
@@ -624,9 +636,10 @@ p.level1 {
   }
 
   div.sourceCode {
-    background-color: #313131 !important;
+    /* background-color: #313131 !important; */
+    background-color: unset !important;
   }
-  code {
+  code, pre {
     color: #aaaaff;
     background-color: #111111 !important;
   }


### PR DESCRIPTION
Add consistent styling to the code-blocks. Style is based on the styling used on the [tutorial](https://curl.se/docs/tutorial.html) page.

Essentially, the code blocks:

 - Have a solid background
 - Expand the duration of nested code
 - Have a constant font color
 
See [support-repo](https://github.com/jhauga/support-repo/tree/curl-www-pre-code-style) for a demo. There, most of the affected pages can be viewed:

- Use the fixed helper on the right of each page to:
  - Toggle the new `curl.css` of this PR back to the old style
    - Pages start off using the new `curl.css`
  - Toggle light/dark mode

The differences can be instantly rendered there.

![demo.gif](https://github.com/jhauga/support-repo/blob/curl-www-pre-code-style/demo.gif?raw=true)

## Style Samples

These are screenshots from [dev/code-style.html](https://curl.se/dev/code-style.html#:~:text=Function%20invoke%20with%20an%20open%20parenthesis:) of a code-block in the `Column alignment` section.

### New `curl.css` Code Block

![new.png](https://github.com/jhauga/support-repo/blob/curl-www-pre-code-style/img/new.png?raw=true)

### Old `curl.css` Code Block

![old.png](https://github.com/jhauga/support-repo/blob/curl-www-pre-code-style/img/old.png?raw=true)