### PR TITLE
_example-warn: tone down warning

### DIFF
--- a/libcurl/c/_example-warn.html
+++ b/libcurl/c/_example-warn.html
@@ -1,9 +1,9 @@
 <h2>Notice</h2>
 
 <div style="color: #000; background-color: #ffff80; padding: 8px 8px 8px 8px;">
-This source code example is <strong>simplified</strong> and ignores return
-codes and error checks to a large extent. We do this to highlight the libcurl
-function calls and related options and reduce unrelated code.
+This source code example is <strong>simplified</strong> and may ignore return
+codes and error checks. We do this to highlight the libcurl function calls and
+related options and reduce unrelated code.
 <p>
 A real-world application does of course properly check every return value and
 exit correctly at the first serious error.


### PR DESCRIPTION
Example code has been updated last year to check for more/most
real-world errors.

Refs:
https://github.com/curl/curl/commit/64ed2ea1968e912439442dd3ad6addd8a2acfb84
https://github.com/curl/curl/pull/19055
https://github.com/curl/curl/commit/4c7507daf913c2e7f3ff96b1ff92e467a3d2ece5
https://github.com/curl/curl/pull/19053
