### PR TITLE
rtmp: remove since it is not supported anymore

### DIFF
--- a/_index.html
+++ b/_index.html
@@ -139,7 +139,7 @@ SUBTITLE(curl supports)
 <tr class="l"><td class="left">Protocols</td>
 
   <td class="right"> DICT, FILE, FTP, FTPS, GOPHER, GOPHERS, HTTP, HTTPS,
-IMAP, IMAPS, LDAP, LDAPS, MQTT, MQTTS, POP3, POP3S, RTMP, RTMPS, RTSP, SCP,
+IMAP, IMAPS, LDAP, LDAPS, MQTT, MQTTS, POP3, POP3S, RTSP, SCP,
 SFTP, SMB, SMBS, SMTP, SMTPS, TELNET, TFTP, WS, WSS </td></tr>
 
 <tr class="r"><td class="left">Proxies</td>

--- a/docs/_comparison-table.html
+++ b/docs/_comparison-table.html
@@ -138,7 +138,6 @@ TITLE(Compare curl with other download tools)
   FEAT( POP3 )                   YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( Recursive downloads )    no___ YES__ YES__ no___ YES__ no___ YES__ no___ no___ ENDLINE
   FEAT( Retry failed downloads)  YES__ YES__ YES__ YES__ YES__ YES__ YES__ no___ no___ ENDLINE
-  FEAT( RTMP )                   YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( RTSP )                   YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( Same file multi connect) no___ no___ YES__ no___ YES__ YES__ no___ no___ no___ ENDLINE
   FEAT( SCP )                    YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE

--- a/libcurl/_index.html
+++ b/libcurl/_index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="libcurl is a free and easy-to-use
  client-side URL transfer library, supporting DICT, FILE, FTP, FTPS, GOPHER,
  GOPHERS, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS, MQTT, MQTTS, POP3, POP3S,
- RTMP, RTMPS, RTSP, SCP, SFTP, SMB, SMBS, SMTP, SMTPS, TELNET, TFTP, WS and
+ RTSP, SCP, SFTP, SMB, SMBS, SMTP, SMTPS, TELNET, TFTP, WS and
  WSS. libcurl supports SSL certificates, HTTP POST, HTTP PUT, FTP uploading,
  kerberos, HTTP form based upload, proxies, cookies, user+password
  authentication, file transfer resume, http proxy tunneling and more">
@@ -24,7 +24,7 @@ TITLE(libcurl - your network transfer library)
  libcurl is a <a href="/docs/copyright.html" title="free as in both free
  speech and zero price!">free</a> and easy-to-use client-side URL transfer
  library, supporting DICT, FILE, FTP, FTPS, GOPHER, GOPHERS, HTTP, HTTPS,
- IMAP, IMAPS, LDAP, LDAPS, MQTT, MQTTS, POP3, POP3S, RTMP, RTMPS, RTSP, SCP,
+ IMAP, IMAPS, LDAP, LDAPS, MQTT, MQTTS, POP3, POP3S, RTSP, SCP,
  SFTP, SMB, SMBS, SMTP, SMTPS, TELNET, TFTP, WS and WSS. libcurl supports SSL
  certificates, HTTP POST, HTTP PUT, FTP uploading, HTTP form based upload,
  proxies, HTTP/2, HTTP/3, cookies, user+password authentication (Basic,

--- a/windows/_microsoft.html
+++ b/windows/_microsoft.html
@@ -51,7 +51,7 @@ SUBTITLE(Disabled features)
 <ul>
   <li> no Public Suffix List (PSL) support, making it impossible to prevent "super cookies"
   <li> no support for HTTP/2 or HTTP/3
-  <li> no support for GOPHER(S), LDAP(S), RTMP, RTSP, SCP, SFTP
+  <li> no support for GOPHER(S), LDAP(S), RTSP, SCP, SFTP
   <li> no brotli or zstd compression
 </ul>
 


### PR DESCRIPTION
Fixes #587

(patch by @nafmo)