### PR TITLE
download: provide metadata in a table on top

### DIFF
--- a/_download.html
+++ b/_download.html
@@ -37,10 +37,14 @@ TITLE(Releases and Downloads)
  The curl project mostly provides source packages. Other packages are kindly
  provided by external persons and organizations.
 
-SUBTITLE(Source Archives)
+SUBTITLE(Information)
+<table class="download">
+<tr><td> Version: </td><td> <b>curl __STABLE</b> </td></tr>
+<tr><td> Release date: </td><td> <b>DATE(__RELDATE)</b> </td></tr>
+<tr><td> Updates: </td><td> <b><a href="/ch/__STABLE.html">curl __STABLE changelog</a></b> </td></tr>
+</table>
 <p>
- <b>curl __STABLE</b>, Released on the DATE(__RELDATE). <a href="/ch/__STABLE.html">Changelog for __STABLE</a>.
-
+SUBTITLE(Source Archives)
 <table class="download">
   <tr>
     <td class="download"><a href="/download/curl-__STABLE.tar.xz" type="application/x-xz">curl-__STABLE.tar.xz</a></td>


### PR DESCRIPTION
A cleaner look

## Before

<img width="977" height="482" alt="image" src="https://github.com/user-attachments/assets/9e4dd6f1-2641-4350-bbdb-dcbf9c441a75" />

## With this PR

<img width="961" height="687" alt="image" src="https://github.com/user-attachments/assets/278fac0a-c3a3-4502-8113-dbb373bc412f" />
