### PR TITLE
drop PKGBUILD for Arch Linux

### DIFF
--- a/snapshots/_index.html
+++ b/snapshots/_index.html
@@ -27,7 +27,6 @@ TITLE(Daily curl snapshots)
 
 SUBTITLE(Binary snapshots)
 <ul>
-<li><a href="https://github.com/pheiduck/curl-daily/releases">Arch Linux</a>
 <li><a href="https://github.com/curl/curl-container/pkgs/container/curl-container%2Fcurl">Docker</a>
 <li><a href="https://github.com/curl/curl-for-win/actions/workflows/daily.yml">Windows, macOS, Linux MUSL/glibc</a>
 </ul>


### PR DESCRIPTION
I do not have the time anymore to maintain the Package and CI so I am about to drop the Repo on my side. If someone will keep it alive please reach out in comments. Roadmap:
- 2026/06/14 Repo will be archived.
- 2026/06/28 Repo will be removed.