### PR TITLE
info: add a `sha256` field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,13 +76,13 @@ web-editing.html: _web-editing.html $(MAINPARTS)
 foot.html: _foot.html $(MAINPARTS)
 	$(ACTION)
 
-index.html: _index.html $(MAINPARTS) release.t packstat.t
+index.html: _index.html $(MAINPARTS) $(RELEASE) packstat.t
 	$(ACTION)
 
-download/index.html: release.t mk-download.pl
+download/index.html: $(RELEASE) mk-download.pl
 	./mk-download.pl > $@
 
-info: _info packstat.t
+info: _info packstat.t $(RELEASE)
 	$(ACTION)
 
 $(RELEASE): Makefile
@@ -91,6 +91,7 @@ $(RELEASE): Makefile
 	@echo "#define __RELDATE $(RELDATE)" >>$(RELEASE)
 	@echo "#define __NEXTDATE $(NEXTDATE)" >>$(RELEASE)
 	@echo "#define __STABLETAG $(STABLE)" | sed 's/\./_/g' >> $(RELEASE)
+	echo "#define __SHA256 `sha256sum download/curl-$(STABLE).tar.gz | cut -f1 '-d '`" >> $(RELEASE)
 
 $(STAT): download.html Makefile
 	@echo "fixing $(STAT)"

--- a/_info
+++ b/_info
@@ -3,6 +3,7 @@
 Version: __STABLE
 Date: __RELDATE
 Download: https://curl.se/download/curl-__STABLE.tar.gz
+sha256: __SHA256
 Changelog: https://curl.se/ch/__STABLE.html
 git tag: curl-__STABLETAG
 Packages: __PACKS


### PR DESCRIPTION
Since the 'info' file is an excellent way for the world to get automated information about the most recent curl release and tarball, providing a sha256sum for the file might help users to make sure they get all the right content.