### PR TITLE
dev/vuln-disclosure: mention summer of bliss

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -112,7 +112,7 @@ internals.html: _internals.html $(MAINPARTS) internals.gen
 internals.gen: $(DOCROOT)/INTERNALS.md
 	$(MARKDOWN) < $< > $@
 
-vuln-disclosure.html: _vuln-disclosure.html $(MAINPARTS) disclosure.gen
+vuln-disclosure.html: _vuln-disclosure.html $(MAINPARTS) disclosure.gen bliss.t
 	$(ACTION)
 disclosure.gen: $(DOCROOT)/VULN-DISCLOSURE-POLICY.md
 	$(MARKDOWN) < $< > $@

--- a/dev/_vuln-disclosure.html
+++ b/dev/_vuln-disclosure.html
@@ -12,6 +12,10 @@
 
 WHERE2(Development, "/dev/", Vulnerability Disclosure Policy)
 
+#include "bliss.t"
+
+<div style="clear: both;"/>
+
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="/docs/security.html">curl CVEs</a>

--- a/dev/bliss.t
+++ b/dev/bliss.t
@@ -1,0 +1,6 @@
+<div class="badge"> <b>curl summer of bliss 2026</b><p>During the month of
+July, the curl project pauses its vulnerability disclosure program and does
+not accept any reports. Any and all findings will have to wait. We resume
+accepting reports again on August 3, 2026. (<a
+href="https://daniel.haxx.se/blog/2026/06/15/curl-summer-of-bliss/">read
+more</a>)</div>


### PR DESCRIPTION
It appears like this on my local build:

<img width="1557" height="698" alt="image" src="https://github.com/user-attachments/assets/cc3b8af5-67de-49b7-9861-684764a2b352" />
