### PR TITLE
windows: fix latest x64 SSH signature link

### DIFF
--- a/windows/_index.html
+++ b/windows/_index.html
@@ -77,7 +77,7 @@ SUBTITLE(Fixed URLs)
 / <a download="curl-win64a-latest.zip.asc" href="latest.cgi?p=win64a-mingw.zip.asc">pgp</a>
 / <a download="curl-win64a-latest.zip.minisig" href="latest.cgi?p=win64a-mingw.zip.minisig">minisign</a>
 / <a download="curl-win64a-latest.zip.sigstore" href="latest.cgi?p=win64a-mingw.zip.sigstore">cosign</a>
-/ <a download="curl-win64a-latest.zip.sig" href="latest.cgi?p=win64a-mingw.zip.sigstore">SSH</a>
+/ <a download="curl-win64a-latest.zip.sig" href="latest.cgi?p=win64a-mingw.zip.sig">SSH</a>
 / <a download="curl-win64a-latest.zip.txt" href="latest.cgi?p=win64a-mingw.zip.txt">sha256</a><br>
 #endif
 


### PR DESCRIPTION
Reported-by: ed0d2b2ce19451f2 on github
Fixes #605
Follow-up to d076643cc05a1059dc5feeeb11f49b0bf45896f3 #554