### PR TITLE
singlevuln: polish

### DIFF
--- a/docs/_singlevuln.templ
+++ b/docs/_singlevuln.templ
@@ -2,6 +2,12 @@
 <html>
 <head> <title>Vulnerabilities in curl %version</title>
 #include "css.t"
+<style type="text/css">
+.contents {
+  max-width: 60em;
+  overflow: auto;
+}
+</style>
 </head>
 
 #define CURL_DOCS

--- a/docs/vulntable.pl
+++ b/docs/vulntable.pl
@@ -58,6 +58,12 @@ sub sev2color {
     return "black";
 }
 
+sub sevtext {
+    my ($severity) = @_;
+
+    return uc(substr($severity, 0, 1));
+}
+
 sub single {
     my ($sum, $str, $date, $vernum, $vulns, $nextrel, $prevrel) = @_;
 
@@ -69,12 +75,15 @@ sub single {
     my $vulnplural;
 
     if($vulnnum) {
-        $vulnhtml = "<table><tr class=\"tabletop\"><th>Flaw</th><th>From version</th><th>To and including</th></tr>";
+        $vulnhtml = "<table><tr class=\"tabletop\"><th>S</th><th>Flaw</th><th>First</th><th>Last</th></tr>";
 
         for my $i (@v) {
-            $vulnhtml .= sprintf("<tr class=\"%s\"><td><a href=\"%s\">%s</a></td><td><a href=\"vuln-%s.html\">%s</a></td><td><a href=\"vuln-%s.html\">%s</a></td></tr>\n",
-                                 $odd&1?"even":"odd",
-                                 $vurl[$i], $vulndesc[$i],
+            $vulnhtml .= sprintf("<tr>".
+                                 "<td style=\"color: %s; border-radius: 8px; border: 2px %s solid;\" title=\"Severity %s\">%s</td>".
+
+                                 "<td><a href=\"%s\">%s: %s</a></td><td><a href=\"vuln-%s.html\">%s</a></td><td><a href=\"vuln-%s.html\">%s</a></td></tr>\n",
+                                 sev2color($sev[$i]), sev2color($sev[$i]), $sev[$i], sevtext($sev[$i]),
+                                 $vurl[$i], $cve[$i], $vulndesc[$i],
                                  $vstart[$i], $vstart[$i],
                                  $vstop[$i], $vstop[$i]);
             $odd++;


### PR DESCRIPTION
For the generated per-release page that lists all vulnerbilties that particular version is vulnerable to:

- make it wider
- add "severity" column and show them like they are shown in the main listing with single letter, colors and a rounded border
- add CVE ID to the flaw name
- rename the table headers for the versions to first/last to match the main vulnerability listing page
- no longer use the odd/even classes