### PR TITLE
Navigation System Accessibility Overhaul

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -59,3 +59,6 @@ jobs:
 
       - name: make
         run: make
+
+      - name: navcheck
+        run: make navcheck

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,10 @@ perlcheck:
 	   fi \
 	done)
 
+.PHONY: navcheck
+navcheck:
+	./navcheck.pl
+
 full: all
 	@cd libcurl; make
 

--- a/_menu.html
+++ b/_menu.html
@@ -2,6 +2,7 @@
 #define __MENU
 
 #include "setup.t"
+#include "nav.t"
 
 #ifndef NOBODY
 <body>
@@ -9,108 +10,108 @@
 
 <div class="main">
 
-<div class="menu">
+SITENAV_OPEN
 
 #include "symbol.t"
 
-<div class="dropdown">
-  <a class="dropbtn" href="/download.html">Download</a>
-  <div class="dropdown-content">
-    <a href="https://github.com/curl/curl">Browse source</a>
-    <a href="/ch/">Changelog</a>
-    <a href="/rc/">Release candidates</a>
-    <a href="/docs/releases.html">Release log</a>
-    <a href="/tiny/">tiny-curl</a>
-  </div>
-</div>
+SITENAV_CONTROLS
+SITENAV_LIST_OPEN
+  SITENAV_GROUP_OPEN(Download)
+        SITENAV_OVERVIEW(/download.html, Download overview)
+        <li><a href="https://github.com/curl/curl">Browse source</a></li>
+        <li><a href="/ch/">Changelog</a></li>
+        <li><a href="/rc/">Release candidates</a></li>
+        <li><a href="/docs/releases.html">Release log</a></li>
+        <li><a href="/tiny/">tiny-curl</a></li>
+  SITENAV_GROUP_CLOSE
 
-<div class="dropdown">
-  <a class="dropbtn" href="/docs/">Documentation</a>
-  <div class="dropdown-content">
-    <a href="/docs/projdocs.html">Project</a>
-      <small>
-      <a href="/docs/faq.html">FAQ</a>
-      <a href="/docs/help-us.html">&nbsp; Help us</a>
-      <a href="/docs/knownbugs.html">&nbsp; Known bugs</a>
-      <a href="/docs/knownrisks.html">&nbsp; Known risks</a>
-      <a href="/docs/todo.html">&nbsp; TODO</a>
-      </small>
-    <a href="/docs/protdocs.html">Protocols</a>
-      <small>
-      <a href="/docs/caextract.html">&nbsp; CA bundle</a>
-      <a href="/docs/http-cookies.html">&nbsp; HTTP Cookies</a>
-      <a href="/docs/sslcerts.html">&nbsp; SSL Certs</a>
-      </small>
-    <a href="/docs/reldocs.html">Releases</a>
-      <small>
-      <a href="/docs/security.html">&nbsp; Security</a>
-      <a href="/docs/verify.html">&nbsp; Verify</a>
-      <a href="/docs/versions.html">&nbsp; Version numbers</a>
-      <a href="/docs/vulnerabilities.html">&nbsp; Vulnerabilities</a>
-      </small>
-    <a href="/docs/tooldocs.html">curl tool</a>
-      <small>
-      <a href="/docs/manpage.html">&nbsp; man page</a>
-      <a href="/docs/tutorial.html">&nbsp; Tutorial</a>
-      <a href="/docs/httpscripting.html">&nbsp; HTTP scripting</a>
-      </small>
-    <a href="/trurl/">trurl</a>
-    <a href="/wcurl/">wcurl</a>
-    <a href="/docs/videos/">Videos</a>
-    <a href="/docs/whodocs.html">Who and Why</a>
-  </div>
-</div>
+  SITENAV_GROUP_OPEN(Documentation)
+        SITENAV_OVERVIEW(/docs/, Documentation overview)
+        <li class="sitenav-subgroup">
+          <a href="/docs/projdocs.html">Project</a>
+          <ul class="sitenav-submenu-nested">
+            <li><a href="/docs/faq.html">FAQ</a></li>
+            <li><a href="/docs/help-us.html">Help us</a></li>
+            <li><a href="/docs/knownbugs.html">Known bugs</a></li>
+            <li><a href="/docs/knownrisks.html">Known risks</a></li>
+            <li><a href="/docs/todo.html">TODO</a></li>
+          </ul>
+        </li>
+        <li class="sitenav-subgroup">
+          <a href="/docs/protdocs.html">Protocols</a>
+          <ul class="sitenav-submenu-nested">
+            <li><a href="/docs/caextract.html">CA bundle</a></li>
+            <li><a href="/docs/http-cookies.html">HTTP Cookies</a></li>
+            <li><a href="/docs/sslcerts.html">SSL Certs</a></li>
+          </ul>
+        </li>
+        <li class="sitenav-subgroup">
+          <a href="/docs/reldocs.html">Releases</a>
+          <ul class="sitenav-submenu-nested">
+            <li><a href="/docs/security.html">Security</a></li>
+            <li><a href="/docs/verify.html">Verify</a></li>
+            <li><a href="/docs/versions.html">Version numbers</a></li>
+            <li><a href="/docs/vulnerabilities.html">Vulnerabilities</a></li>
+          </ul>
+        </li>
+        <li class="sitenav-subgroup">
+          <a href="/docs/tooldocs.html">curl tool</a>
+          <ul class="sitenav-submenu-nested">
+            <li><a href="/docs/manpage.html">man page</a></li>
+            <li><a href="/docs/tutorial.html">Tutorial</a></li>
+            <li><a href="/docs/httpscripting.html">HTTP scripting</a></li>
+          </ul>
+        </li>
+        <li><a href="/trurl/">trurl</a></li>
+        <li><a href="/wcurl/">wcurl</a></li>
+        <li><a href="/docs/videos/">Videos</a></li>
+        <li><a href="/docs/whodocs.html">Who and Why</a></li>
+  SITENAV_GROUP_CLOSE
 
-<div class="dropdown">
-  <a class="dropbtn" href="/libcurl/">libcurl</a>
-  <div class="dropdown-content">
-    <a href="/libcurl/c/">API</a>
-    <a href="/libcurl/c/example.html">Examples</a>
-    <a href="/libcurl/features.html">Features</a>
-    <a href="/mail/list.cgi?list=curl-library">Mailing list</a>
-    <a href="/libcurl/c/symbols-in-versions.html">Symbols</a>
-    <a href="/libcurl/using/">Using libcurl</a>
-    <a href="/libcurl/c/libcurl-tutorial.html">Tutorial</a>
-  </div>
-</div>
+  SITENAV_GROUP_OPEN(libcurl)
+        SITENAV_OVERVIEW(/libcurl/, libcurl overview)
+        <li><a href="/libcurl/c/">API</a></li>
+        <li><a href="/libcurl/c/example.html">Examples</a></li>
+        <li><a href="/libcurl/features.html">Features</a></li>
+        <li><a href="/mail/list.cgi?list=curl-library">Mailing list</a></li>
+        <li><a href="/libcurl/c/symbols-in-versions.html">Symbols</a></li>
+        <li><a href="/libcurl/using/">Using libcurl</a></li>
+        <li><a href="/libcurl/c/libcurl-tutorial.html">Tutorial</a></li>
+  SITENAV_GROUP_CLOSE
 
-<div class="dropdown">
-  <a class="dropbtn" href="/gethelp.html">Get Help</a>
-  <div class="dropdown-content">
-    <a href="https://lists.haxx.se/listinfo/curl-library">curl-library</a>
-    <a href="https://lists.haxx.se/listinfo/curl-users">curl-users</a>
-    <a href="/docs/irc.html">IRC / chat</a>
-    <a href="/mail/">Mailing lists</a>
-    <a href="/book.html">Everything curl [book]</a>
-    <a href="/docs/videos/">Video presentations</a>
-    <a href="https://github.com/curl/curl/issues">Report a bug</a>
-    <a href="/dev/vuln-disclosure.html">Report security issue</a>
-    <a href="/support.html">Paid support</a>
-  </div>
-</div>
+  SITENAV_GROUP_OPEN(Get Help)
+        SITENAV_OVERVIEW(/gethelp.html, Get Help overview)
+        <li><a href="https://lists.haxx.se/listinfo/curl-library">curl-library</a></li>
+        <li><a href="https://lists.haxx.se/listinfo/curl-users">curl-users</a></li>
+        <li><a href="/docs/irc.html">IRC / chat</a></li>
+        <li><a href="/mail/">Mailing lists</a></li>
+        <li><a href="/book.html">Everything curl [book]</a></li>
+        <li><a href="/docs/videos/">Video presentations</a></li>
+        <li><a href="https://github.com/curl/curl/issues">Report a bug</a></li>
+        <li><a href="/dev/vuln-disclosure.html">Report security issue</a></li>
+        <li><a href="/support.html">Paid support</a></li>
+  SITENAV_GROUP_CLOSE
 
-<div class="dropdown">
-  <a class="dropbtn" href="/dev/">Development</a>
-  <div class="dropdown-content">
-    <a href="/dev/builds.html">Autobuilds</a>
-    <a href="/dev/code-review.html">Code review</a>
-    <a href="/dev/code-style.html">Code style</a>
-    <a href="/dev/contribute.html">Contribute</a>
-    <a href="/dashboard.html">Dashboard</a>
-    <a href="/dev/dependencies.html">Dependencies</a>
-    <a href="/dev/deprecate.html">Deprecate</a>
-    <a href="/dev/release-notes.html">Release Notes</a>
-    <a href="/dev/release-procedure.html">Release Procedure</a>
-    <a href="/dev/roadmap.html">Roadmap</a>
-    <a href="/dev/runtests.html">Run Tests</a>
-    <a href="/rfc/">Specifications</a>
-    <a href="/dev/testcurl.html">Test curl</a>
-    <a href="/dev/tests-overview.html">Tests Overview</a>
-    <a href="/dev/vuln-disclosure.html">Vulnerability Disclosure Policy</a>
-  </div>
-</div>
-
-</div>
+  SITENAV_GROUP_OPEN(Development)
+        SITENAV_OVERVIEW(/dev/, Development overview)
+        <li><a href="/dev/builds.html">Autobuilds</a></li>
+        <li><a href="/dev/code-review.html">Code review</a></li>
+        <li><a href="/dev/code-style.html">Code style</a></li>
+        <li><a href="/dev/contribute.html">Contribute</a></li>
+        <li><a href="/dashboard.html">Dashboard</a></li>
+        <li><a href="/dev/dependencies.html">Dependencies</a></li>
+        <li><a href="/dev/deprecate.html">Deprecate</a></li>
+        <li><a href="/dev/release-notes.html">Release Notes</a></li>
+        <li><a href="/dev/release-procedure.html">Release Procedure</a></li>
+        <li><a href="/dev/roadmap.html">Roadmap</a></li>
+        <li><a href="/dev/runtests.html">Run Tests</a></li>
+        <li><a href="/rfc/">Specifications</a></li>
+        <li><a href="/dev/testcurl.html">Test curl</a></li>
+        <li><a href="/dev/tests-overview.html">Tests Overview</a></li>
+        <li><a href="/dev/vuln-disclosure.html">Vulnerability Disclosure Policy</a></li>
+  SITENAV_GROUP_CLOSE
+SITENAV_LIST_CLOSE
+SITENAV_CLOSE
 
 #ifdef SHOW_ALERT
 #include "alert.t"

--- a/curl.css
+++ b/curl.css
@@ -619,6 +619,23 @@ div.yellowbox {
   }
 }
 
+@media screen and (min-width: 1001px) and (hover: hover) {
+  /*
+   * This CSS-only preview creates a semantic incongruence: a hovered submenu
+   * is visible while <details> remains closed, so screen readers continue to
+   * announce it as collapsed. The tradeoff applies only during committed,
+   * direct use of a mouse or another hover-capable pointer. Moving the pointer
+   * away removes the preview; clicking opens <details>, aligns the visual and
+   * semantic states, and keeps the submenu visible. Keyboard and touch continue
+   * to use native disclosure behavior. Suppress previews while any disclosure
+   * is explicitly open.
+   */
+  .sitenav-list:not(:has(.sitenav-disclosure[open]))
+    .sitenav-disclosure:not([open]):hover::details-content {
+    content-visibility: visible;
+  }
+}
+
 /* Final site-navigation breakpoint: the widest section menu needs this room. */
 @media screen and (max-width: 1000px) {
   .sitenav {

--- a/curl.css
+++ b/curl.css
@@ -292,6 +292,216 @@ div.curlsymbol a img:hover {
   width: 42px;
 }
 
+/* ------------------------------------------------------------------------ */
+/* site header navigation */
+
+.sitenav {
+  box-sizing: border-box;
+  position: relative;
+  z-index: 3;
+  width: 100%;
+  min-height: 47px;
+  padding: 1.5px 3.2em;
+  background-color: #093754;
+  color: #ffffff;
+  font-family: sans-serif;
+  font-size: 24px;
+  line-height: 1.3;
+}
+
+.sitenav *,
+.sitenav *::before,
+.sitenav *::after {
+  box-sizing: border-box;
+}
+
+.sitenav-home {
+  position: absolute;
+  top: 50%;
+  left: .45em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 2px;
+  transform: translateY(-50%);
+}
+
+.sitenav-home:hover {
+  background-color: transparent;
+}
+
+.sitenav-state,
+.sitenav-toggle {
+  display: none;
+}
+
+.sitenav-list,
+.sitenav-submenu,
+.sitenav-submenu-nested {
+  margin-top: 0;
+  margin-bottom: 0;
+  list-style: none;
+}
+
+.sitenav-list {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+}
+
+.sitenav-item {
+  position: relative;
+  margin: 0;
+  padding: 0;
+}
+
+.sitenav-item:focus-within {
+  z-index: 102;
+}
+
+.sitenav-disclosure {
+  height: 100%;
+}
+
+.sitenav-summary,
+.sitenav-link,
+.sitenav > .sitenav-list > .sitenav-item > .menuitem,
+.sitenav > .sitenav-list > .sitenav-item > .itemselect {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  margin: 0;
+  padding: .3em .6em;
+  border: 0;
+  background-color: transparent;
+  color: #ffffff;
+  font: inherit;
+  line-height: inherit;
+  text-align: left;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.sitenav-summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+.sitenav-summary::marker {
+  content: "";
+}
+
+.sitenav-summary::-webkit-details-marker {
+  display: none;
+}
+
+.sitenav-summary:hover,
+.sitenav-disclosure[open] > .sitenav-summary,
+.sitenav-link:hover,
+.sitenav > .sitenav-list > .sitenav-item > .menuitem:hover,
+.sitenav > .sitenav-list > .sitenav-item > .itemselect:hover {
+  background-color: #0c486d;
+  color: #d0d0d0;
+}
+
+.sitenav-summary:focus-visible,
+.sitenav-link:focus-visible,
+.sitenav > .sitenav-list > .sitenav-item > .menuitem:focus-visible,
+.sitenav > .sitenav-list > .sitenav-item > .itemselect:focus-visible,
+.sitenav-home:focus-visible {
+  outline: 3px solid #ffd75e;
+  outline-offset: -3px;
+}
+
+.sitenav > .sitenav-list > .sitenav-item > .itemselect {
+  font-weight: bold;
+}
+
+.sitenav-submenu {
+  box-sizing: border-box;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  min-width: 10em;
+  max-width: min(24em, calc(100vw - 1em));
+  max-height: calc(100vh - 4em);
+  margin: 0;
+  padding: .35em 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  background-color: #f9f9f9;
+  box-shadow: 0 8px 16px rgba(0,0,0,0.2);
+  color: #093754;
+  font-size: 80%;
+  line-height: 1.25;
+  text-align: left;
+}
+
+.sitenav-list > .sitenav-item:nth-last-child(-n+2) > .sitenav-disclosure > .sitenav-submenu {
+  right: 0;
+  left: auto;
+}
+
+.sitenav-submenu li,
+.sitenav-submenu-nested li {
+  margin: 0;
+  padding: 0;
+}
+
+.sitenav-submenu a {
+  box-sizing: border-box;
+  display: block;
+  min-height: 36px;
+  padding: .3em .65em;
+  color: #093754;
+  overflow-wrap: anywhere;
+  text-align: left;
+  text-decoration: none;
+}
+
+.sitenav-submenu a:hover {
+  background-color: #f1f1f1;
+  color: #093754;
+}
+
+.sitenav-submenu a:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 3px solid #093754;
+  outline-offset: -3px;
+}
+
+.sitenav-overview,
+.sitenav-subgroup > a {
+  font-weight: bold;
+}
+
+.sitenav-overview {
+  border-bottom: 1px solid #c7d3db;
+}
+
+.sitenav-submenu-divider {
+  border-top: 1px solid #c7d3db;
+  margin-top: .25em !important;
+  padding-top: .25em !important;
+}
+
+.sitenav-submenu-nested {
+  margin: 0;
+  padding: 0 0 .2em .8em;
+  font-size: 85%;
+}
+
+.sitenav-submenu-nested a {
+  font-weight: normal;
+}
+
 .relatedbox {
   box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
   color: #000000;
@@ -403,9 +613,192 @@ div.yellowbox {
     margin-right: 5px;
   }
 }
+
+@media screen and (min-width: 1001px) {
+  /* Extend the open summary behind its submenu for outside-click dismissal. */
+  .sitenav-disclosure[open] > .sitenav-summary::after {
+    position: fixed;
+    inset: 47px 0 0;
+    z-index: 99;
+    content: "";
+    cursor: default;
+  }
+}
+
+/* Final site-navigation breakpoint: the widest section menu needs this room. */
 @media screen and (max-width: 1000px) {
   div.curlsymbol {
     display: none;
+  }
+
+  .sitenav {
+    display: grid;
+    grid-template-columns: minmax(44px, 1fr) auto;
+    align-items: center;
+    min-height: 47px;
+    padding: 1.5px .4em;
+    font-size: 22px;
+  }
+
+  .sitenav-home {
+    position: static;
+    grid-column: 1;
+    grid-row: 1;
+    justify-self: start;
+    transform: none;
+  }
+
+  .sitenav-state {
+    position: fixed;
+    top: 0;
+    right: 0;
+    display: block;
+    width: 1px;
+    height: 1px;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    border: 0;
+    white-space: nowrap;
+  }
+
+  .sitenav-toggle {
+    grid-column: 2;
+    grid-row: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    padding: .35em .55em;
+    border: 1px solid rgba(255,255,255,.55);
+    border-radius: 3px;
+    color: #ffffff;
+    cursor: pointer;
+    font: inherit;
+    gap: .45em;
+  }
+
+  .sitenav-toggle:hover,
+  .sitenav-state:checked + .sitenav-toggle {
+    background-color: #0c486d;
+  }
+
+  .sitenav-state:focus-visible + .sitenav-toggle {
+    outline: 3px solid #ffd75e;
+    outline-offset: 2px;
+  }
+
+  /* Extend the menu toggle behind the menu for outside-click dismissal. */
+  .sitenav-state:checked + .sitenav-toggle::after {
+    position: fixed;
+    inset: 47px 0 0;
+    z-index: 1;
+    content: "";
+    cursor: default;
+  }
+
+  .sitenav-toggle-icon,
+  .sitenav-toggle-icon::before,
+  .sitenav-toggle-icon::after {
+    display: block;
+    width: 1em;
+    height: 2px;
+    background-color: currentColor;
+    transition: transform 150ms ease, opacity 150ms ease;
+  }
+
+  .sitenav-toggle-icon {
+    position: relative;
+  }
+
+  .sitenav-toggle-icon::before,
+  .sitenav-toggle-icon::after {
+    position: absolute;
+    left: 0;
+    content: "";
+  }
+
+  .sitenav-toggle-icon::before {
+    transform: translateY(-.32em);
+  }
+
+  .sitenav-toggle-icon::after {
+    transform: translateY(.32em);
+  }
+
+  .sitenav-state:checked + .sitenav-toggle .sitenav-toggle-icon {
+    background-color: transparent;
+  }
+
+  .sitenav-state:checked + .sitenav-toggle .sitenav-toggle-icon::before {
+    transform: rotate(45deg);
+  }
+
+  .sitenav-state:checked + .sitenav-toggle .sitenav-toggle-icon::after {
+    transform: rotate(-45deg);
+  }
+
+  .sitenav-list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    display: none;
+    width: 100%;
+    max-height: calc(100vh - 47px);
+    max-height: calc(100dvh - 47px);
+    padding: .25em .4em .4em;
+    overflow-x: hidden;
+    overflow-y: auto;
+    background-color: #093754;
+    box-shadow: 0 8px 16px rgba(0,0,0,.2);
+    overscroll-behavior-y: contain;
+  }
+
+  .sitenav-state:checked ~ .sitenav-list {
+    display: block;
+    z-index: 2;
+  }
+
+  .sitenav-item {
+    border-top: 1px solid rgba(255,255,255,.22);
+  }
+
+  .sitenav-disclosure {
+    height: auto;
+  }
+
+  .sitenav-summary,
+  .sitenav-link,
+  .sitenav > .sitenav-list > .sitenav-item > .menuitem,
+  .sitenav > .sitenav-list > .sitenav-item > .itemselect {
+    width: 100%;
+    min-height: 44px;
+    padding: .45em .55em;
+  }
+
+  .sitenav-submenu,
+  .sitenav-list > .sitenav-item:nth-last-child(-n+2) > .sitenav-disclosure > .sitenav-submenu {
+    position: static;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    max-height: none;
+    padding: .2em 0 .4em .6em;
+    overflow: visible;
+    box-shadow: inset 3px 0 0 #c7d3db;
+    font-size: 90%;
+  }
+
+  .sitenav-submenu a {
+    min-height: 44px;
+    padding: .55em .7em;
+  }
+
+  .sitenav-submenu-nested {
+    padding-left: .65em;
   }
 }
 /* Filtering menus on the autobuild page */
@@ -568,6 +961,29 @@ p.level1 {
     background-color: #606060;
   }
 
+  .sitenav-submenu {
+    background-color: #4c4c4c;
+    color: #fafafa;
+  }
+
+  .sitenav-submenu a {
+    color: #fafafa;
+  }
+
+  .sitenav-submenu a:hover {
+    background-color: #606060;
+    color: #ffffff;
+  }
+
+  .sitenav-submenu a:focus-visible {
+    outline-color: #ffd75e;
+  }
+
+  .sitenav-overview,
+  .sitenav-submenu-divider {
+    border-color: #858585;
+  }
+
   .relatedbox {
     background-color: #313131;
     color: white;
@@ -641,5 +1057,34 @@ p.level1 {
   code, pre {
     color: #aaaaff;
     background-color: #111111 !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sitenav-toggle-icon,
+  .sitenav-toggle-icon::before,
+  .sitenav-toggle-icon::after {
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .sitenav-toggle {
+    border-color: ButtonText;
+  }
+
+  .sitenav-state:focus-visible + .sitenav-toggle,
+  .sitenav-summary:focus-visible,
+  .sitenav-link:focus-visible,
+  .sitenav > .sitenav-list > .sitenav-item > .menuitem:focus-visible,
+  .sitenav > .sitenav-list > .sitenav-item > .itemselect:focus-visible,
+  .sitenav-home:focus-visible,
+  .sitenav-submenu a:focus-visible {
+    outline-color: Highlight;
+  }
+
+  .sitenav-submenu {
+    border: 1px solid CanvasText;
+    box-shadow: none;
   }
 }

--- a/curl.css
+++ b/curl.css
@@ -271,25 +271,19 @@ tr.hide {
   font-size: 26px;
 }
 
-/* the top menu symbol box */
-div.curlsymbol {
-  float: left;
-  position: absolute;
-}
-
-div.curlsymbol a {
+.curlsymbol {
   cursor: pointer;
 }
 
-div.curlsymbol a img {
+.curlsymbol img {
+  display: block;
   width: 41px;
 }
 
 /* unset the default img:hover, and add hover-effect */
-div.curlsymbol a img:hover {
+.curlsymbol img:hover {
   background-color: unset !important;
   box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-  width: 42px;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -627,10 +621,6 @@ div.yellowbox {
 
 /* Final site-navigation breakpoint: the widest section menu needs this room. */
 @media screen and (max-width: 1000px) {
-  div.curlsymbol {
-    display: none;
-  }
-
   .sitenav {
     display: grid;
     grid-template-columns: minmax(44px, 1fr) auto;

--- a/dev/_menu.html
+++ b/dev/_menu.html
@@ -2,6 +2,7 @@
 #define __MENU
 
 #include "setup.t"
+#include "nav.t"
 
 #ifndef NOBODY
 
@@ -14,47 +15,48 @@
 #define REF(link,text) <a href=link>text</a>
 
 <div class="main">
-<div class="menu">
+SITENAV_OPEN
 
 #include "symbol.t"
 
-<div class="dropdown">
-  <a class="dropbtn" href="/dev/">Dev-related docs</a>
-  <div class="dropdown-content">
-    <a href="/dev/code-review.html">Code Review</a>
-    <a href="/dev/code-style.html">Code Style</a>
-    <a href="/dev/contribute.html">Contribute</a>
-    <a href="/dev/deprecate.html">Deprecate</a>
-    <a href="/dev/dependencies.html">Dependency versions</a>
-    <a href="/dev/experimental.html">Experimental</a>
-    <a href="/dev/new-protocol.html">New protocol</a>
-    <a href="/dev/release-procedure.html">Release procedure</a>
-    <a href="/dev/roadmap.html">Roadmap</a>
-    <a href="/dev/runtests.html">Run tests</a>
-    <a href="/dev/source.html">Source code</a>
-    <a href="/rfc/">Specifications</a>
-    <a href="https://testclutch.curl.se/">Test Clutch</a>
-    <a href="/dev/testcurl.html">Test curl</a>
-    <a href="/dev/test-fileformat.html">Test case file format</a>
-    <a href="/dev/tests-overview.html">Tests Overview</a>
-    <a href="/dev/vuln-disclosure.html">Vulnerability Disclosure Policy</a>
-  </div>
-</div>
-<div class="dropdown">
-  <a class="dropbtn" href="/dev/./">Current status</a>
-  <div class="dropdown-content">
-    <a href="/dev/builds.html">Autobuilds</a>
-    <a href="/snapshots/">Daily snapshots</a>
-    <a href="/dashboard.html">Dashboard</a>
-    <a href="/dev/feature-window.html">Feature window</a>
-    <a href="/gitstats/">git stats</a>
-    <a href="https://github.com/curl/curl/issues" target="_blank">Issues (github)</a>
-    <a href="https://github.com/curl/curl/pulls" target="_blank">Pull requests (github)</a>
-    <a href="/dev/release-notes.html">Release Notes</a>
-  </div>
-</div>
+SITENAV_CONTROLS
+SITENAV_LIST_OPEN
 
-</div>
+SITENAV_GROUP_OPEN(Dev-related docs)
+  SITENAV_OVERVIEW(/dev/, Dev-related docs overview)
+  <li><a href="/dev/code-review.html">Code Review</a></li>
+  <li><a href="/dev/code-style.html">Code Style</a></li>
+  <li><a href="/dev/contribute.html">Contribute</a></li>
+  <li><a href="/dev/deprecate.html">Deprecate</a></li>
+  <li><a href="/dev/dependencies.html">Dependency versions</a></li>
+  <li><a href="/dev/experimental.html">Experimental</a></li>
+  <li><a href="/dev/new-protocol.html">New protocol</a></li>
+  <li><a href="/dev/release-procedure.html">Release procedure</a></li>
+  <li><a href="/dev/roadmap.html">Roadmap</a></li>
+  <li><a href="/dev/runtests.html">Run tests</a></li>
+  <li><a href="/dev/source.html">Source code</a></li>
+  <li><a href="/rfc/">Specifications</a></li>
+  <li><a href="https://testclutch.curl.se/">Test Clutch</a></li>
+  <li><a href="/dev/testcurl.html">Test curl</a></li>
+  <li><a href="/dev/test-fileformat.html">Test case file format</a></li>
+  <li><a href="/dev/tests-overview.html">Tests Overview</a></li>
+  <li><a href="/dev/vuln-disclosure.html">Vulnerability Disclosure Policy</a></li>
+SITENAV_GROUP_CLOSE
+
+SITENAV_GROUP_OPEN(Current status)
+  SITENAV_OVERVIEW(/dev/, Current status overview)
+  <li><a href="/dev/builds.html">Autobuilds</a></li>
+  <li><a href="/snapshots/">Daily snapshots</a></li>
+  <li><a href="/dashboard.html">Dashboard</a></li>
+  <li><a href="/dev/feature-window.html">Feature window</a></li>
+  <li><a href="/gitstats/">git stats</a></li>
+  <li><a href="https://github.com/curl/curl/issues" target="_blank">Issues (github)</a></li>
+  <li><a href="https://github.com/curl/curl/pulls" target="_blank">Pull requests (github)</a></li>
+  <li><a href="/dev/release-notes.html">Release Notes</a></li>
+SITENAV_GROUP_CLOSE
+
+SITENAV_LIST_CLOSE
+SITENAV_CLOSE
 
 START_OF_MAIN
 #endif

--- a/docs/_menu.html
+++ b/docs/_menu.html
@@ -5,91 +5,87 @@
 #include "setup.t"
 #endif
 
+#include "nav.t"
+
 #ifndef NOBODY
 <body>
 #endif
 
 <div class="main">
-<div class="menu">
+SITENAV_OPEN
 
 #include "symbol.t"
 
+SITENAV_CONTROLS
+SITENAV_LIST_OPEN
+
 #ifdef DOCS_OVERVIEW
-LINK(/docs/, Docs Overview)
+SITENAV_SELECTED_LINK(/docs/, Docs Overview)
 #else
-VLINK(/docs/, Docs Overview, Documentation Overview)
+SITENAV_TITLED_LINK(/docs/, Docs Overview, Documentation Overview)
 #endif
 
-<div class="dropdown">
-  <a class="dropbtn" href="/docs/projdocs.html">Project</a>
-  <div class="dropdown-content">
-    <a href="/docs/bugs.html">Bug Report</a>
-    <a href="/docs/code-of-conduct.html">Code of conduct</a>
-    <a href="/docs/libs.html">Dependencies</a>
-    <a href="/donation.html">Donate</a>
-    <a href="/docs/faq.html">FAQ</a>
-    <a href="/docs/features.html">Features</a>
-    <a href="/docs/governance.html">Governance</a>
-    <a href="/docs/history.html">History</a>
-    <a href="/docs/install.html">Install</a>
-    <a href="/docs/knownbugs.html">Known Bugs</a>
-    <a href="/docs/knownrisks.html">Known Risks</a>
-    <a href="/logo/">Logo</a>
-    <a href="/docs/todo.html">TODO</a>
-    <a href="/about.html">website Info</a>
-  </div>
-</div>
+SITENAV_GROUP_OPEN(Project)
+  SITENAV_OVERVIEW(/docs/projdocs.html, Project overview)
+  <li><a href="/docs/bugs.html">Bug Report</a></li>
+  <li><a href="/docs/code-of-conduct.html">Code of conduct</a></li>
+  <li><a href="/docs/libs.html">Dependencies</a></li>
+  <li><a href="/donation.html">Donate</a></li>
+  <li><a href="/docs/faq.html">FAQ</a></li>
+  <li><a href="/docs/features.html">Features</a></li>
+  <li><a href="/docs/governance.html">Governance</a></li>
+  <li><a href="/docs/history.html">History</a></li>
+  <li><a href="/docs/install.html">Install</a></li>
+  <li><a href="/docs/knownbugs.html">Known Bugs</a></li>
+  <li><a href="/docs/knownrisks.html">Known Risks</a></li>
+  <li><a href="/logo/">Logo</a></li>
+  <li><a href="/docs/todo.html">TODO</a></li>
+  <li><a href="/about.html">website Info</a></li>
+SITENAV_GROUP_CLOSE
 
-<div class="dropdown">
-  <a class="dropbtn" href="/docs/protdocs.html">Protocols</a>
-  <div class="dropdown-content">
-    <a href="/docs/caextract.html">CA Extract</a>
-    <a href="/docs/http-cookies.html">HTTP cookies</a>
-    <a href="/docs/http3.html">HTTP/3</a>
-    <a href="/docs/mqtt.html">MQTT</a>
-    <a href="/docs/sslcerts.html">SSL certs</a>
-    <a href="/docs/ssl-compared.html">SSL libs compared</a>
-    <a href="/docs/url-syntax.html">URL syntax</a>
-    <a href="/docs/websocket.html">WebSocket</a>
-  </div>
-</div>
+SITENAV_GROUP_OPEN(Protocols)
+  SITENAV_OVERVIEW(/docs/protdocs.html, Protocols overview)
+  <li><a href="/docs/caextract.html">CA Extract</a></li>
+  <li><a href="/docs/http-cookies.html">HTTP cookies</a></li>
+  <li><a href="/docs/http3.html">HTTP/3</a></li>
+  <li><a href="/docs/mqtt.html">MQTT</a></li>
+  <li><a href="/docs/sslcerts.html">SSL certs</a></li>
+  <li><a href="/docs/ssl-compared.html">SSL libs compared</a></li>
+  <li><a href="/docs/url-syntax.html">URL syntax</a></li>
+  <li><a href="/docs/websocket.html">WebSocket</a></li>
+SITENAV_GROUP_CLOSE
 
-<div class="dropdown">
-  <a class="dropbtn" href="/docs/reldocs.html">Releases</a>
-  <div class="dropdown-content">
-    <a href="/ch/">Changelog</a>
-    <a href="/docs/security.html">curl CVEs</a>
-    <a href="/docs/releases.html">Release Table</a>
-    <a href="/docs/versions.html">Version Numbering</a>
-    <a href="/docs/verify.html">Verify</a>
-    <a href="/docs/vulnerabilities.html">Vulnerabilities</a>
-  </div>
-</div>
+SITENAV_GROUP_OPEN(Releases)
+  SITENAV_OVERVIEW(/docs/reldocs.html, Releases overview)
+  <li><a href="/ch/">Changelog</a></li>
+  <li><a href="/docs/security.html">curl CVEs</a></li>
+  <li><a href="/docs/releases.html">Release Table</a></li>
+  <li><a href="/docs/versions.html">Version Numbering</a></li>
+  <li><a href="/docs/verify.html">Verify</a></li>
+  <li><a href="/docs/vulnerabilities.html">Vulnerabilities</a></li>
+SITENAV_GROUP_CLOSE
 
-<div class="dropdown">
-  <a class="dropbtn" href="/docs/tooldocs.html">Tool</a>
-  <div class="dropdown-content">
-    <a href="/docs/comparison-table.html">Comparison Table</a>
-    <a href="/docs/manpage.html">curl man page</a>
-    <a href="/docs/httpscripting.html">HTTP Scripting</a>
-    <a href="/docs/mk-ca-bundle.html">mk-ca-bundle</a>
-    <a href="/docs/tutorial.html">Tutorial</a>
-    <a href="optionswhen.html">When options were added</a>
-  </div>
-</div>
+SITENAV_GROUP_OPEN(Tool)
+  SITENAV_OVERVIEW(/docs/tooldocs.html, Tool overview)
+  <li><a href="/docs/comparison-table.html">Comparison Table</a></li>
+  <li><a href="/docs/manpage.html">curl man page</a></li>
+  <li><a href="/docs/httpscripting.html">HTTP Scripting</a></li>
+  <li><a href="/docs/mk-ca-bundle.html">mk-ca-bundle</a></li>
+  <li><a href="/docs/tutorial.html">Tutorial</a></li>
+  <li><a href="/docs/optionswhen.html">When options were added</a></li>
+SITENAV_GROUP_CLOSE
 
-<div class="dropdown">
-  <a class="dropbtn" href="/docs/whodocs.html">Who and Why</a>
-  <div class="dropdown-content">
-    <a href="/docs/companies.html">Companies</a>
-    <a href="/docs/copyright.html">Copyright</a>
-    <a href="/sponsors.html">Sponsors</a>
-    <a href="/docs/thanks.html">Thanks</a>
-    <a href="/docs/thename.html">The name</a>
-  </div>
-</div>
+SITENAV_GROUP_OPEN(Who and Why)
+  SITENAV_OVERVIEW(/docs/whodocs.html, Who and Why overview)
+  <li><a href="/docs/companies.html">Companies</a></li>
+  <li><a href="/docs/copyright.html">Copyright</a></li>
+  <li><a href="/sponsors.html">Sponsors</a></li>
+  <li><a href="/docs/thanks.html">Thanks</a></li>
+  <li><a href="/docs/thename.html">The name</a></li>
+SITENAV_GROUP_CLOSE
 
-</div>
+SITENAV_LIST_CLOSE
+SITENAV_CLOSE
 
 #ifdef SHOW_ALERT
 #include "../alert.t"

--- a/libcurl/_menu.html
+++ b/libcurl/_menu.html
@@ -1,45 +1,53 @@
 
+#ifndef __MENU
+#define __MENU
+
 #include "setup.t"
+#include "nav.t"
 
 #ifndef NOBODY
 <body>
 #endif
 
 <div class="main">
-<div class="menu">
+SITENAV_OPEN
 
 #include "symbol.t"
 
+SITENAV_CONTROLS
+SITENAV_LIST_OPEN
+
 #ifdef LIBCURL_MAIN
-LINK("", libcurl )
+SITENAV_SELECTED_LINK(/libcurl/, libcurl)
 #else
-VLINK("/libcurl/", libcurl, Front page of the libcurl section)
+SITENAV_TITLED_LINK(/libcurl/, libcurl, Front page of the libcurl section)
 #endif
 
-<div class="dropdown">
-  <a class="dropbtn" href="/libcurl/">Docs</a>
-  <div class="dropdown-content">
-    <a href="/libcurl/abi.html">ABI</a>
-    <a href="/libcurl/c/allfuncs.html">All functions</a>
-    <a href="/libcurl/c/">API</a>
-    <a href="/libcurl/bindings.html">Bindings</a>
-    <a href="/libcurl/competitors.html">Competitors</a>
-    <a href="/libcurl/c/example.html">Examples</a>
-    <a href="/libcurl/features.html">Features</a>
-    <a href="/mail/list.cgi?list=curl-library">Mailing list</a>
-    <a href="/libcurl/relatedlibs.html">Related libs</a>
-    <a href="/libcurl/using/">Using libcurl</a>
-    <a href="/libcurl/security.html">Security</a>
-    <a href="/libcurl/c/symbols-in-versions.html">Symbols</a>
-    <a href="/libcurl/c/libcurl-tutorial.html">Tutorial</a>
-    <a href="/libcurl/theysay.html">Testimonials</a>
-  </div>
-</div>
+SITENAV_GROUP_OPEN(Docs)
+  SITENAV_OVERVIEW(/libcurl/, Docs overview)
+  <li><a href="/libcurl/abi.html">ABI</a></li>
+  <li><a href="/libcurl/c/allfuncs.html">All functions</a></li>
+  <li><a href="/libcurl/c/">API</a></li>
+  <li><a href="/libcurl/bindings.html">Bindings</a></li>
+  <li><a href="/libcurl/competitors.html">Competitors</a></li>
+  <li><a href="/libcurl/c/example.html">Examples</a></li>
+  <li><a href="/libcurl/features.html">Features</a></li>
+  <li><a href="/mail/list.cgi?list=curl-library">Mailing list</a></li>
+  <li><a href="/libcurl/relatedlibs.html">Related libs</a></li>
+  <li><a href="/libcurl/using/">Using libcurl</a></li>
+  <li><a href="/libcurl/security.html">Security</a></li>
+  <li><a href="/libcurl/c/symbols-in-versions.html">Symbols</a></li>
+  <li><a href="/libcurl/c/libcurl-tutorial.html">Tutorial</a></li>
+  <li><a href="/libcurl/theysay.html">Testimonials</a></li>
+SITENAV_GROUP_CLOSE
 
-</div>
+SITENAV_LIST_CLOSE
+SITENAV_CLOSE
 
 #ifdef SHOW_ALERT
 #include "../alert.t"
 #endif
 
 START_OF_MAIN
+
+#endif

--- a/libcurl/c/_menu.html
+++ b/libcurl/c/_menu.html
@@ -1,64 +1,69 @@
 
+#ifndef __MENU
+#define __MENU
+
 #include "setup.t"
+#include "nav.t"
 
 #ifndef NOBODY
 <body>
 #endif
 
 <div class="main">
-<div class="menu">
+SITENAV_OPEN
 
 #include "symbol.t"
 
+SITENAV_CONTROLS
+SITENAV_LIST_OPEN
+
 #ifdef DOCS_OVERVIEW
-LINK("/libcurl/c/libcurl.html", API Overview)
+SITENAV_SELECTED_LINK(/libcurl/c/libcurl.html, API Overview)
 #else
-VLINK("/libcurl/c/libcurl.html", API Overview, Overview)
+SITENAV_TITLED_LINK(/libcurl/c/libcurl.html, API Overview, Overview)
 #endif
 
-<div class="dropdown">
-  <a class="dropbtn" href="/libcurl/c/">Docs</a>
-  <div class="dropdown-content">
-    <a href="/libcurl/c/libcurl-easy.html">API: easy</a>
-    <a href="/libcurl/c/libcurl-multi.html">API: multi</a>
-    <a href="/libcurl/c/libcurl-share.html">API: share</a>
-    <a href="/libcurl/c/libcurl-url.html">API: URL</a>
-    <a href="/libcurl/c/libcurl-ws.html">API: WebSocket</a>
-    <a href="/libcurl/c/libcurl-env.html">Environment vars</a>
-    <a href="/libcurl/c/libcurl-errors.html">Errors</a>
-    <a href="/libcurl/c/example.html">Examples</a>
-    <a href="/libcurl/security.html">Security</a>
-    <a href="/libcurl/c/symbols-in-versions.html">Symbols</a>
-    <a href="/libcurl/c/libcurl-tutorial.html">Tutorial</a>
-    <hr>
-    <a href="/libcurl/c/easy_setopt_options.html">easy setopt options</a>
-    <a href="/libcurl/c/easy_getinfo_options.html">easy getinfo options</a>
-    <a href="/libcurl/c/multi_setopt_options.html">multi setopt options</a>
-    <a href="/libcurl/c/tls-options.html">TLS options</a>
-  </div>
-</div>
-<div class="dropdown">
-  <a class="dropbtn" href="/libcurl/c/">Functions</a>
-  <div class="dropdown-content">
-    <a href="/libcurl/c/allfuncs.html">All functions</a>
-    <a href="/libcurl/c/curl_easy_getinfo.html">curl_easy_getinfo</a>
-    <a href="/libcurl/c/curl_easy_init.html">curl_easy_init</a>
-    <a href="/libcurl/c/curl_easy_perform.html">curl_easy_perform</a>
-    <a href="/libcurl/c/curl_easy_reset.html">curl_easy_reset</a>
-    <a href="/libcurl/c/curl_easy_setopt.html">curl_easy_setopt</a>
-    <a href="/libcurl/c/curl_multi_add_handle.html">curl_multi_add_handle</a>
-    <a href="/libcurl/c/curl_multi_init.html">curl_multi_init</a>
-    <a href="/libcurl/c/curl_multi_perform.html">curl_multi_perform</a>
-    <a href="/libcurl/c/curl_multi_remove_handle.html">curl_multi_remove_handle</a>
-    <a href="/libcurl/c/curl_multi_setopt.html">curl_multi_setopt</a>
-  </div>
-</div>
+SITENAV_GROUP_OPEN(Docs)
+  SITENAV_OVERVIEW(/libcurl/c/, Docs overview)
+  <li><a href="/libcurl/c/libcurl-easy.html">API: easy</a></li>
+  <li><a href="/libcurl/c/libcurl-multi.html">API: multi</a></li>
+  <li><a href="/libcurl/c/libcurl-share.html">API: share</a></li>
+  <li><a href="/libcurl/c/libcurl-url.html">API: URL</a></li>
+  <li><a href="/libcurl/c/libcurl-ws.html">API: WebSocket</a></li>
+  <li><a href="/libcurl/c/libcurl-env.html">Environment vars</a></li>
+  <li><a href="/libcurl/c/libcurl-errors.html">Errors</a></li>
+  <li><a href="/libcurl/c/example.html">Examples</a></li>
+  <li><a href="/libcurl/security.html">Security</a></li>
+  <li><a href="/libcurl/c/symbols-in-versions.html">Symbols</a></li>
+  <li><a href="/libcurl/c/libcurl-tutorial.html">Tutorial</a></li>
+  <li class="sitenav-submenu-divider"><a href="/libcurl/c/easy_setopt_options.html">easy setopt options</a></li>
+  <li><a href="/libcurl/c/easy_getinfo_options.html">easy getinfo options</a></li>
+  <li><a href="/libcurl/c/multi_setopt_options.html">multi setopt options</a></li>
+  <li><a href="/libcurl/c/tls-options.html">TLS options</a></li>
+SITENAV_GROUP_CLOSE
 
+SITENAV_GROUP_OPEN(Functions)
+  SITENAV_OVERVIEW(/libcurl/c/, Functions overview)
+  <li><a href="/libcurl/c/allfuncs.html">All functions</a></li>
+  <li><a href="/libcurl/c/curl_easy_getinfo.html">curl_easy_getinfo</a></li>
+  <li><a href="/libcurl/c/curl_easy_init.html">curl_easy_init</a></li>
+  <li><a href="/libcurl/c/curl_easy_perform.html">curl_easy_perform</a></li>
+  <li><a href="/libcurl/c/curl_easy_reset.html">curl_easy_reset</a></li>
+  <li><a href="/libcurl/c/curl_easy_setopt.html">curl_easy_setopt</a></li>
+  <li><a href="/libcurl/c/curl_multi_add_handle.html">curl_multi_add_handle</a></li>
+  <li><a href="/libcurl/c/curl_multi_init.html">curl_multi_init</a></li>
+  <li><a href="/libcurl/c/curl_multi_perform.html">curl_multi_perform</a></li>
+  <li><a href="/libcurl/c/curl_multi_remove_handle.html">curl_multi_remove_handle</a></li>
+  <li><a href="/libcurl/c/curl_multi_setopt.html">curl_multi_setopt</a></li>
+SITENAV_GROUP_CLOSE
 
-</div>
+SITENAV_LIST_CLOSE
+SITENAV_CLOSE
 
 #ifdef SHOW_ALERT
 #include "alert.t"
 #endif
 
 START_OF_MAIN
+
+#endif

--- a/libcurl/using/Makefile
+++ b/libcurl/using/Makefile
@@ -1,17 +1,15 @@
 ROOT=../..
 
+include $(ROOT)/mainparts.mk
+
 SRCROOT=$(ROOT)/cvssource
 DOCROOT=$(SRCROOT)/docs
 CURL=$(ROOT)
 MAN2HTML= roffit --bare
 
-MAINPARTS= \
- $(ROOT)/_doctype.html \
+MAINPARTS += \
  _menu.html \
- $(ROOT)/setup.t \
- $(ROOT)/where.t \
- ../download.t \
- $(ROOT)/css.t
+ ../download.t
 
 ACTION=@echo preprocessing $@; rm -f -- $@; fcpp -I.. -I$(ROOT) -I../c -WWW -Uunix -P -H -C -V -LL $< $@;
 

--- a/libcurl/using/_menu.html
+++ b/libcurl/using/_menu.html
@@ -1,32 +1,42 @@
+#ifndef __MENU
+#define __MENU
+
 #include "setup.t"
+#include "nav.t"
 
 #ifndef NOBODY
 <body>
 #endif
 
 <div class="main">
-<div class="menu">
+SITENAV_OPEN
 
 #include "symbol.t"
 
+SITENAV_CONTROLS
+SITENAV_LIST_OPEN
+
 #ifdef USING_INDEX
-LINK("/libcurl/using/", Using libcurl )
+SITENAV_SELECTED_LINK(/libcurl/using/, Using libcurl)
 #else
-VLINK("/libcurl/using/", Using libcurl, Using libcurl section)
+SITENAV_TITLED_LINK(/libcurl/using/, Using libcurl, Using libcurl section)
 #endif
 
 #ifdef USING_AUTOCONF
-LINK("/libcurl/using/autoconf.html", autoconf)
+SITENAV_SELECTED_LINK(/libcurl/using/autoconf.html, autoconf)
 #else
-VLINK("/libcurl/using/autoconf.html", autoconf, How to detect libcurl with autoconf)
+SITENAV_TITLED_LINK(/libcurl/using/autoconf.html, autoconf, How to detect libcurl with autoconf)
 #endif
 
 #ifdef USING_CURL_CONFIG
-LINK("/libcurl/using/curl-config.html", curl-config)
+SITENAV_SELECTED_LINK(/libcurl/using/curl-config.html, curl-config)
 #else
-VLINK("/libcurl/using/curl-config.html", curl-config, How to use curl-config)
+SITENAV_TITLED_LINK(/libcurl/using/curl-config.html, curl-config, How to use curl-config)
 #endif
 
-</div>
+SITENAV_LIST_CLOSE
+SITENAV_CLOSE
 
 START_OF_MAIN
+
+#endif

--- a/mail/Makefile
+++ b/mail/Makefile
@@ -5,14 +5,9 @@ DOCROOT=$(SRCROOT)/docs
 CURL=$(ROOT)
 
 include $(ROOT)/setup.mk
+include $(ROOT)/mainparts.mk
 
-MAINPARTS= \
- $(ROOT)/_doctype.html \
- $(CURL)/_menu.html \
- $(CURL)/_footer.html \
- $(CURL)/setup.t \
- $(CURL)/where.t \
- $(ROOT)/css.t
+MAINPARTS += $(CURL)/_menu.html
 
 ACTION=@echo preprocessing $@; rm -f -- $@; fcpp -I.. -I. -WWW -Uunix -P -H -C -V -LL $< $@;
 

--- a/mainparts.mk
+++ b/mainparts.mk
@@ -1,6 +1,8 @@
 MAINPARTS= \
  $(ROOT)/_doctype.html \
  $(ROOT)/setup.t \
+ $(ROOT)/nav.t \
+ $(ROOT)/symbol.t \
  $(ROOT)/where.t \
  $(ROOT)/css.t \
  $(ROOT)/_footer.html

--- a/nav.t
+++ b/nav.t
@@ -1,0 +1,48 @@
+#ifndef __NAV_T
+#define __NAV_T
+
+#define SITENAV_OPEN \
+<nav class="sitenav" aria-label="Primary navigation">
+
+#define SITENAV_CONTROLS \
+<input class="sitenav-state" type="checkbox" id="sitenav-state"> \
+<label class="sitenav-toggle" for="sitenav-state"> \
+  <span class="sitenav-toggle-icon" aria-hidden="true"></span> \
+  <span>Menu</span> \
+</label>
+
+#define SITENAV_LIST_OPEN \
+<ul class="sitenav-list">
+
+#define SITENAV_LIST_CLOSE \
+</ul>
+
+#define SITENAV_CLOSE \
+</nav>
+
+#define SITENAV_GROUP_OPEN(label) \
+<li class="sitenav-item"> \
+  <details class="sitenav-disclosure" name="sitenav-submenus"> \
+    <summary class="sitenav-summary"> \
+      <span class="sitenav-label">label</span> \
+    </summary> \
+    <ul class="sitenav-submenu">
+
+#define SITENAV_GROUP_CLOSE \
+    </ul> \
+  </details> \
+</li>
+
+#define SITENAV_OVERVIEW(url,label) \
+<li><a class="sitenav-overview" href="url">label</a></li>
+
+#define SITENAV_LINK(url,label) \
+<li class="sitenav-item"><a class="sitenav-link" href="url">label</a></li>
+
+#define SITENAV_SELECTED_LINK(url,label) \
+<li class="sitenav-item"><a class="sitenav-link itemselect" href="url" aria-current="page">label</a></li>
+
+#define SITENAV_TITLED_LINK(url,label,titletext) \
+<li class="sitenav-item"><a class="sitenav-link menuitem" href="url" title="titletext">label</a></li>
+
+#endif /* __NAV_T */

--- a/navcheck.pl
+++ b/navcheck.pl
@@ -1,0 +1,158 @@
+#!/usr/bin/env perl
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+use strict;
+use warnings;
+
+use File::Basename qw(basename);
+use File::Find qw(find);
+
+my @problems;
+my %files;
+my $nav_pages = 0;
+
+sub problem {
+    my ($file, $message) = @_;
+    push @problems, "$file: $message";
+}
+
+sub match_count {
+    my ($text, $pattern) = @_;
+    my $count = 0;
+    while($text =~ /$pattern/g) {
+        $count++;
+    }
+    return $count;
+}
+
+sub candidate {
+    my ($path) = @_;
+    my $name = basename($path);
+    return if $name =~ /^_/;
+    return if $name !~ /\.html\z/;
+    $files{$path} = 1 if -f $path;
+}
+
+my $default_scan = !@ARGV;
+my @roots = @ARGV ? @ARGV : ('.');
+for my $root (@roots) {
+    if(-f $root) {
+        candidate($root);
+    }
+    elsif(-d $root) {
+        find({
+            no_chdir => 1,
+            wanted => sub {
+                my $path = $File::Find::name;
+                if(-d $path) {
+                    $File::Find::prune = 1 if basename($path) eq '.git';
+                    return;
+                }
+                candidate($path);
+            }
+        }, $root);
+    }
+    else {
+        problem($root, 'file or directory does not exist');
+    }
+}
+
+my $nav_start = qr{
+    <nav\b
+    (?=[^>]*\bclass\s*=\s*(?:"[^"]*\bsitenav\b[^"]*"|'[^']*\bsitenav\b[^']*'))
+    [^>]*>
+}ix;
+
+my $detail_start = qr{
+    <details\b
+    (?=[^>]*\bclass\s*=\s*(?:"[^"]*\bsitenav-disclosure\b[^"]*"|'[^']*\bsitenav-disclosure\b[^']*'))
+    [^>]*>
+}ix;
+
+my $state_id = qr{\bid\s*=\s*(?:"sitenav-state"|'sitenav-state')}i;
+my $state_for = qr{\bfor\s*=\s*(?:"sitenav-state"|'sitenav-state')}i;
+my $group_name = qr{\bname\s*=\s*(?:"sitenav-submenus"|'sitenav-submenus')}i;
+my $open_attribute = qr{\sopen(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?(?=\s|/?>)}i;
+my $leaked_macro = qr{\b(SITENAV_[A-Z0-9_]+|START_OF_MAIN|__NAV_T|__MENU)\b};
+
+for my $file (sort keys %files) {
+    open(my $input, '<', $file) or do {
+        problem($file, "cannot read: $!");
+        next;
+    };
+    local $/;
+    my $html = <$input>;
+    close($input);
+
+    my %leaked;
+    while($html =~ /$leaked_macro/g) {
+        $leaked{$1} = 1;
+    }
+    if(%leaked) {
+        problem($file, 'leaked FCPP token(s): ' .
+                join(', ', sort keys %leaked));
+    }
+
+    my $nav_count = match_count($html, $nav_start);
+    next if !$nav_count;
+    $nav_pages++;
+
+    my @nav_blocks = ($html =~ /($nav_start.*?<\/nav\s*>)/gis);
+    if($nav_count != 1) {
+        problem($file, "expected one sitenav, found $nav_count");
+    }
+    if(@nav_blocks != $nav_count) {
+        problem($file, 'could not match every sitenav start with a closing </nav>');
+    }
+    next if !@nav_blocks;
+
+    my $nav = join("\n", @nav_blocks);
+    my $id_count = match_count($nav, $state_id);
+    my $for_count = match_count($nav, $state_for);
+    if($id_count != 1) {
+        problem($file, "expected one sitenav-state id, found $id_count");
+    }
+    if($for_count != 1) {
+        problem($file, "expected one sitenav-state label, found $for_count");
+    }
+
+    my @detail_tags = ($nav =~ /($detail_start)/g);
+    my $detail_number = 0;
+    for my $tag (@detail_tags) {
+        $detail_number++;
+        my $name_count = match_count($tag, $group_name);
+        if($name_count != 1) {
+            problem($file, "disclosure $detail_number has $name_count sitenav-submenus name attributes");
+        }
+        if($tag =~ /$open_attribute/) {
+            problem($file, "disclosure $detail_number starts open");
+        }
+    }
+
+    my @detail_blocks = ($nav =~ /($detail_start.*?<\/details\s*>)/gis);
+    if(@detail_blocks != @detail_tags) {
+        problem($file, 'could not match every navigation disclosure with a closing </details>');
+    }
+    $detail_number = 0;
+    for my $details (@detail_blocks) {
+        $detail_number++;
+        if($details !~ /<a\b/i) {
+            problem($file, "disclosure $detail_number contains no links");
+        }
+    }
+}
+
+if($default_scan && !$nav_pages) {
+    problem('navcheck', 'no generated sitenav pages found; run make first');
+}
+
+if(@problems) {
+    print STDERR "$_\n" for @problems;
+    print STDERR 'navcheck: ', scalar(@problems), " problem(s) found\n";
+    exit 1;
+}
+
+print 'navcheck: ', $nav_pages, ' navigation page(s) checked across ',
+    scalar(keys %files), " generated HTML file(s)\n";

--- a/rfc/Makefile
+++ b/rfc/Makefile
@@ -1,13 +1,12 @@
+ROOT=..
+
 SRCROOT=../cvssource
 DOCROOT=$(SRCROOT)/docs
 
-MAINPARTS= \
- ../_doctype.html \
+include $(ROOT)/mainparts.mk
+
+MAINPARTS += \
  ../dev/_menu.html \
- ../_footer.html \
- ../setup.t \
- ../where.t \
- ../css.t \
  Makefile
 
 ACTION=@echo preprocessing $@; rm -f -- $@; fcpp -I../docs -I.. -WWW -Uunix -H -C -V -P -LL $< $@;

--- a/symbol.t
+++ b/symbol.t
@@ -1,5 +1,3 @@
-<div class="curlsymbol">
-  <a href="/">
-    <img src="/logo/curl-white-symbol.svg">
-  </a>
-</div>
+<a class="curlsymbol sitenav-home" href="/" aria-label="curl home">
+  <img src="/logo/curl-white-symbol.svg" alt="">
+</a>

--- a/trurl/_menu.html
+++ b/trurl/_menu.html
@@ -2,6 +2,7 @@
 #define __MENU
 
 #include "setup.t"
+#include "nav.t"
 
 #ifndef NOBODY
 
@@ -14,25 +15,25 @@
 #define REF(link,text) <a href=link>text</a>
 
 <div class="main">
-<div class="menu">
+SITENAV_OPEN
 
 #include "symbol.t"
 
-<div class="dropdown">
-  <a class="dropbtn" href="/">curl.se</a>
-</div>
-<div class="dropdown">
-  <a class="dropbtn" href="/dev/">trurl</a>
-  <div class="dropdown-content">
-    <a href="https://github.com/curl/trurl">GitHub repo</a>
-    <a href="/trurl/manual.html">man page</a>
-  </div>
-</div>
-<div class="dropdown">
-  <a class="dropbtn" href="/wcurl/">wcurl</a>
-</div>
+SITENAV_CONTROLS
+SITENAV_LIST_OPEN
 
-</div>
+SITENAV_LINK(/, curl.se)
+
+SITENAV_GROUP_OPEN(trurl)
+  SITENAV_OVERVIEW(/trurl/, trurl overview)
+  <li><a href="https://github.com/curl/trurl">GitHub repo</a></li>
+  <li><a href="/trurl/manual.html">man page</a></li>
+SITENAV_GROUP_CLOSE
+
+SITENAV_LINK(/wcurl/, wcurl)
+
+SITENAV_LIST_CLOSE
+SITENAV_CLOSE
 
 START_OF_MAIN
 #endif

--- a/wcurl/_menu.html
+++ b/wcurl/_menu.html
@@ -2,6 +2,7 @@
 #define __MENU
 
 #include "setup.t"
+#include "nav.t"
 
 #ifndef NOBODY
 
@@ -14,25 +15,25 @@
 #define REF(link,text) <a href=link>text</a>
 
 <div class="main">
-<div class="menu">
+SITENAV_OPEN
 
 #include "symbol.t"
 
-<div class="dropdown">
-  <a class="dropbtn" href="/">curl.se</a>
-</div>
-<div class="dropdown">
-  <a class="dropbtn" href="/dev/">wcurl</a>
-  <div class="dropdown-content">
-    <a href="https://github.com/curl/wcurl">GitHub repo</a>
-    <a href="/wcurl/code-review.html">man page</a>
-  </div>
-</div>
-<div class="dropdown">
-  <a class="dropbtn" href="/trurl/">trurl</a>
-</div>
+SITENAV_CONTROLS
+SITENAV_LIST_OPEN
 
-</div>
+SITENAV_LINK(/, curl.se)
+
+SITENAV_GROUP_OPEN(wcurl)
+  SITENAV_OVERVIEW(/wcurl/, wcurl overview)
+  <li><a href="https://github.com/curl/wcurl">GitHub repo</a></li>
+  <li><a href="/wcurl/manual.html">man page</a></li>
+SITENAV_GROUP_CLOSE
+
+SITENAV_LINK(/trurl/, trurl)
+
+SITENAV_LIST_CLOSE
+SITENAV_CLOSE
 
 START_OF_MAIN
 #endif


### PR DESCRIPTION
## Description

This replaces the site's hover-dependent navigation with a more accessible system for keyboard, touchscreen, and screen-reader users. It requires no JavaScript and adds no dependencies.

Demo site: [curl.ritovision.com](https://curl.ritovision.com)

The previous submenus were revealed only through CSS `:hover`. Keyboard users could focus the top-level links but could not reliably open their submenus. This also impaired desktop screen-reader users who rely on keyboard navigation. On touchscreens, tapping a hover-dependent category may follow its link instead of reliably opening the submenu, while long-pressing typically opens the browser’s context menu rather than the site navigation. The exact behavior varies by browser, making hover an unreliable way to expose links.

Hover now acts as an optional preview of submenus on wide layouts with hover-capable pointers. Without JavaScript, native `<details>` and `<summary>` elements provide a more reliable interaction model across mouse, keyboard, and touch input. This changes how categories behave: a category label now opens or closes its submenu instead of navigating. To preserve the label’s former destination, a new overview link has been added as the first item in each submenu.

### Desktop Hover Preview and Semantics

The CSS-only hover preview creates a semantic incongruence: while a closed category is hovered, its submenu becomes visible even though the native `<details>` state remains closed. Consequently, screen readers continue to announce the category as collapsed during the preview.

This tradeoff is considered acceptable because it applies only during committed, direct use of a mouse or another hover-capable pointer. The user must deliberately position and keep the pointer over the category to invoke the preview. Moving the pointer away removes it, while clicking the category commits it to the native open state, aligns the visual and semantic states, and keeps the submenu visible after the pointer leaves.

Keyboard and touch interactions do not trigger the preview and continue to use the native disclosure behavior. No destination depends on hover, and previews are disabled whenever a submenu is explicitly open.

I kept the hover enhancement in a separate commit so it can be dropped independently if significant regressions emerge, particularly during mixed-input or assistive-technology use.

### The Implementation

- Uses shared FCPP macros to produce consistent markup across all eight menu variants.
- Keeps the site’s existing page-specific menu variants.
- Groups submenus using the `<details>` `name` attribute, so opening one closes the previous submenu. Browsers without that feature can leave multiple submenus open.
- Treats each category label and its chevron as a single control.
- Adds visible focus states and identifies the current page for assistive technologies.
- Adds optional desktop hover previews on wide layouts with hover-capable pointers and suppresses them while a submenu is explicitly open.
- Adds a labeled mobile menu toggle that opens a viewport-bounded, independently scrollable vertical overlay beneath the sticky header.
- Adds CSS-only transparent backdrops behind open desktop submenus and the mobile menu, allowing an open menu to be dismissed by clicking outside its visible area.
- Keeps the curl logo visible in the narrow header.
- Adds build-time navigation validation and runs it in CI.

The no-JavaScript mobile toggle uses a labeled checkbox, so screen readers announce it as checked or unchecked rather than expanded or collapsed. It remains named, focusable, and keyboard-operable.

**Additional fixes:**

- Corrects the documentation link to `/docs/optionswhen.html`.
- Corrects the trurl and wcurl overview links.
- Corrects the wcurl man-page link to `/wcurl/manual.html`.
- Uses canonical `/libcurl/` and `/dev/` destinations for the selected libcurl item and Current status overview link.
- Prevents the header from causing page-wide horizontal overflow on mobile.

## Testing

I tested the navigation in desktop and mobile versions of Chrome, Firefox, and Edge using mouse, keyboard, and touch input. The behavior was consistent across browsers, viewport sizes, and input methods. Testing covered submenu interaction, forward and reverse keyboard navigation, menu scrolling, sticky positioning, and confirmed that the header no longer causes horizontal overflow at narrow viewport widths.

Build and validation checks:

- `make`
- `make navcheck`
- `make perlcheck`

## Screenshots

Mobile: Android with Chrome, approximately 450px screen width.
Desktop: Windows with Chrome.

### Before (mobile)

<img width="400" alt="mobile menu header" src="https://github.com/user-attachments/assets/282ae639-ed02-4e27-8b70-c1053109ff09" />

<br /><br />


*Long-pressing the category link opens the browser’s context menu over the submenu.*
<img width="400" alt="mobile menu header long pressing " src="https://github.com/user-attachments/assets/97949011-257a-4da6-a91b-bad79099a5dd" />

<br /><br />


### After (mobile)

#### Unopened
*The chevrons have since been updated to point up when unopened/collapsed.*
<img width="400" alt="unopened mobile menu header" src="https://github.com/user-attachments/assets/e843fab2-46d9-4bc5-9335-25624f711815" />

<br /><br />

#### Opened
*The chevron has since been updated to point down when opened/expanded.*
<img width="400" alt="opened mobile menu" src="https://github.com/user-attachments/assets/df79f10c-f2c1-4944-bdea-7a64101cd741" />

<br /><br />

#### Opened with open dropdown

*The opened dropdown is vertically scrollable to reveal additional content*
<img width="400" alt="opened mobile menu with opened dropdown" src="https://github.com/user-attachments/assets/95d6eaac-41b1-4364-aacc-564d16df9e1e" />

<br /><br />

### Before (desktop)

#### Default

<img width="1078" height="831" alt="curl-desktop-before" src="https://github.com/user-attachments/assets/ca1fa280-a40f-4e7a-a848-05474a1263be" />

<br /><br />

#### Opened


<img width="1078" height="831" alt="curl-desktop-open-before" src="https://github.com/user-attachments/assets/58f6b222-67ca-4b7b-8a66-edf7665c1d5e" />

<br /><br />


### After (desktop)

#### Default

<img width="1078" height="831" alt="curl-desktop" src="https://github.com/user-attachments/assets/ecfd4e24-893f-4794-a464-dd4ad1228550" />

<br /><br />

#### Opened

<img width="1078" height="831" alt="curl-desktop-open" src="https://github.com/user-attachments/assets/1bdf365e-a650-4921-a4a3-6fb5cf554f0c" />



