### PR TITLE
logo: generate a better logo page

### DIFF
--- a/logo/Makefile
+++ b/logo/Makefile
@@ -16,10 +16,13 @@ PAGES = index.html
 
 all: $(PAGES)
 
-index.html: README.md $(MAINPARTS)
-	$(GITHUB) $< > $@
+index.html: _index.html readme.gen $(MAINPARTS) Makefile
+	$(ACTION)
+
+readme.gen: README.md Makefile
+	$(GITHUB) $< | sed -e 's/img src/img class="logo" src/g' > $@
 
 full: all
 
 clean:
-	rm -f -- $(PAGES)
+	rm -f -- $(PAGES) *.gen

--- a/logo/README.md
+++ b/logo/README.md
@@ -16,7 +16,7 @@ donated to the curl project on May 26 2016.
 
 Applied minor fixes and tweaks on January 6, 2026 (by vsz).
 
-[![curl logo](curl-logo.svg)]()
+![curl logo](curl-logo.svg)
 
 | File                                             | Size  | Resolution | Format          |
 |--------------------------------------------------|-------|------------|-----------------|
@@ -28,7 +28,7 @@ Applied minor fixes and tweaks on January 6, 2026 (by vsz).
 
 ## The curl symbol
 
-[![curl symbol](curl-symbol.svg)]()
+![curl symbol](curl-symbol.svg)]
 
 | File                                                       | Size | Resolution | Format          |
 |------------------------------------------------------------|------|------------|-----------------|
@@ -54,7 +54,7 @@ Further minimization by: [erinaceus](https://chaos.social/@erinaceus), vsz
 
 ## curl up
 
-[![curl up logo](curl-up.svg)]()
+![curl up logo](curl-up.svg)]
 
 | File                       | Size | Resolution | Format |
 |----------------------------|------|------------|--------|

--- a/logo/_index.html
+++ b/logo/_index.html
@@ -1,0 +1,24 @@
+#include "_doctype.html"
+<html lang="en">
+<head>
+<title>curl</title>
+#include "css.t"
+<style>
+img.logo {
+    max-width: 60%;
+}
+</style>
+</head>
+
+#define CURL_LOGO
+
+#include "_menu.html"
+#include "setup.t"
+
+WHERE1(logos)
+
+#include "readme.gen"
+ 
+#include "_footer.html"
+</body>
+</html>


### PR DESCRIPTION
Using the top-menu and standard templates.

Make all images no wider than 60%, which fixes the major previous issue where the SVGs would display super wide.