### PR TITLE
.htaccess: remove block-all-mixed-content from the CSP

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -120,7 +120,7 @@ AddType application/x-bzip2 .bz2
 AddType application/x-tar .tar
 AddType application/x-pem-file .pem
 
-Header set Content-Security-Policy: "upgrade-insecure-requests; block-all-mixed-content; default-src 'none'; img-src 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
+Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; img-src 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
 Header set Cross-Origin-Embedder-Policy: "require-corp"
 Header set Cross-Origin-Opener-Policy: "same-origin"
 Header set Cross-Origin-Resource-Policy: "same-origin"

--- a/.htaccess
+++ b/.htaccess
@@ -144,7 +144,7 @@ Header unset Cross-Origin-Resource-Policy:
 # https://support.google.com/programmable-search/thread/60663049?hl=en
 # The hash is for the inline script in sitesearch.t
 <FilesMatch "^search\.html$|^list\.cgi$">
-Header set Content-Security-Policy: "upgrade-insecure-requests; block-all-mixed-content; default-src 'self' curl.se cse.google.com www.google.com www.googleapis.com clients1.google.com; style-src 'unsafe-inline' 'self' curl.se www.google.com; script-src 'unsafe-eval' 'self' curl.se cse.google.com www.google.com clients1.google.com 'sha256-n9QfETfN26toA8vPrDtfLIC9jm4B8HE2KsS/pOkgPJ4=';"
+Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'self' curl.se cse.google.com www.google.com www.googleapis.com clients1.google.com; style-src 'unsafe-inline' 'self' curl.se www.google.com; script-src 'unsafe-eval' 'self' curl.se cse.google.com www.google.com clients1.google.com 'sha256-n9QfETfN26toA8vPrDtfLIC9jm4B8HE2KsS/pOkgPJ4=';"
 </FilesMatch>
 
 <ifmodule mod_expires.c>

--- a/dev/.htaccess
+++ b/dev/.htaccess
@@ -1,2 +1,2 @@
 # Tight CSP since we use Javascript on these pages
-Header set Content-Security-Policy: "upgrade-insecure-requests; block-all-mixed-content; default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self' 'nonce-t7K7Blwdw9vw'; frame-ancestors 'none'; require-trusted-types-for 'script';"
+Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self' 'nonce-t7K7Blwdw9vw'; frame-ancestors 'none'; require-trusted-types-for 'script';"

--- a/dl/.htaccess
+++ b/dl/.htaccess
@@ -10,4 +10,4 @@ ExpiresActive Off
 </ifmodule>
 
 Header always append Cache-Control: private
-Header set Content-Security-Policy: "upgrade-insecure-requests; block-all-mixed-content; default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
+Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"


### PR DESCRIPTION
It is officially deprecated and ignored by current browsers.

URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/block-all-mixed-content

Follow-up to 4a13fe97