### PR TITLE
.htaccess: try disabling CSP `unsafe-inline`

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -121,7 +121,7 @@ AddType application/x-bzip2 .bz2
 AddType application/x-tar .tar
 AddType application/x-pem-file .pem
 
-Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; img-src 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
+Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; img-src 'self'; style-src 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
 Header set Cross-Origin-Embedder-Policy: "require-corp"
 Header set Cross-Origin-Opener-Policy: "same-origin"
 Header set Cross-Origin-Resource-Policy: "same-origin"


### PR DESCRIPTION
Keep it for the search page, where we know it's necessary.

Follow-up to 4a13fe97abea5c66a1e78298710b56d7ecc94776 #574

---

Searching for `<script` shows these results, which suggests it's safe
to enable it for the rest of the repo:
```
dev/_builds.html:<script type="text/javascript" src="dev.js"></script>
dl/mod_entry.cgi:lheader($title, "<script type=\"text/javascript\" src=\"mod.js\"></script>\n");
sitesearch.t:<script class="sitesearch">
```