### PR TITLE
docs: add a security docs page and a 'security' menu

### DIFF
--- a/_menu.html
+++ b/_menu.html
@@ -48,10 +48,15 @@ SITENAV_LIST_OPEN
         <li class="sitenav-subgroup">
           <a href="/docs/reldocs.html">Releases</a>
           <ul class="sitenav-submenu-nested">
-            <li><a href="/docs/security.html">Security</a></li>
-            <li><a href="/docs/verify.html">Verify</a></li>
+            <li><a href="/docs/releases.html">Release log</a></li>
             <li><a href="/docs/versions.html">Version numbers</a></li>
-            <li><a href="/docs/vulnerabilities.html">Vulnerabilities</a></li>
+          </ul>
+        </li>
+        <li class="sitenav-subgroup">
+          <a href="/docs/secdocs.html">Security</a>
+          <ul class="sitenav-submenu-nested">
+            <li><a href="/docs/security.html">curl CVEs</a></li>
+            <li><a href="/docs/vulnerabilities.html">Vulnerability table</a></li>
           </ul>
         </li>
         <li class="sitenav-subgroup">

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -271,10 +271,11 @@ PAGES = \
  reldocs.html \
  releases.csv \
  releases.html \
- security.html \
- security-m.html \
- security-h.html \
+ secdocs.html \
  security-c.html \
+ security-h.html \
+ security-m.html \
+ security.html \
  ssl-ciphers.html \
  ssl-compared.html \
  sslcerts.html \
@@ -313,6 +314,9 @@ projdocs.html: _projdocs.html $(MAINPARTS)
 	$(ACTION)
 
 reldocs.html: _reldocs.html $(MAINPARTS)
+	$(ACTION)
+
+secdocs.html: _secdocs.html $(MAINPARTS)
 	$(ACTION)
 
 protdocs.html: _protdocs.html $(MAINPARTS)

--- a/docs/_menu.html
+++ b/docs/_menu.html
@@ -58,11 +58,18 @@ SITENAV_GROUP_CLOSE
 SITENAV_GROUP_OPEN(Releases)
   SITENAV_OVERVIEW(/docs/reldocs.html, Releases overview)
   <li><a href="/ch/">Changelog</a></li>
-  <li><a href="/docs/security.html">curl CVEs</a></li>
   <li><a href="/docs/releases.html">Release Table</a></li>
   <li><a href="/docs/versions.html">Version Numbering</a></li>
   <li><a href="/docs/verify.html">Verify</a></li>
-  <li><a href="/docs/vulnerabilities.html">Vulnerabilities</a></li>
+SITENAV_GROUP_CLOSE
+
+SITENAV_GROUP_OPEN(Security)
+  SITENAV_OVERVIEW(/docs/secdocs.html, Security overview)
+  <li><a href="/docs/audits.html">Security Audits</a></li>
+  <li><a href="/docs/security.html">curl CVEs</a></li>
+  <li><a href="/dev/advisory.html">Security advisory details</a></li>
+  <li><a href="/docs/vulnerabilities.html">Vulnerability table</a></li>
+  <li><a href="/dev/vuln-disclosure.html">Vulnerability Disclosure Policy</a></li>
 SITENAV_GROUP_CLOSE
 
 SITENAV_GROUP_OPEN(Tool)

--- a/docs/_projdocs.html
+++ b/docs/_projdocs.html
@@ -17,7 +17,9 @@ TITLE(Project)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="/docs/">Docs Overview</a>
+<br><a href="/dev/">Development docs</a>
 <br><a href="reldocs.html">Release docs</a>
+<br><a href="secdocs.html">Security docs</a>
 </div>
 <p>
   This section is for documentation associated to the project to some degree.

--- a/docs/_reldocs.html
+++ b/docs/_reldocs.html
@@ -18,9 +18,10 @@ TITLE(Releases)
 <b>Related:</b>
 <br><a href="/docs/">Docs Overview</a>
 <br><a href="projdocs.html">Project docs</a>
+<br><a href="secdocs.html">Security docs</a>
 </div>
 <p>
-  Information about and related to curl releases and security.
+  Information about and related to curl releases.
 
 <ul>
 <li>
@@ -33,18 +34,9 @@ TITLE(Releases)
   <a href="releases.html">Release Table</a> - lists all releases, with release
   date, number of bug fixes and so on.
 <li>
-  <a href="security.html">curl CVE page</a> - all publicized security problems
-  listed and thoroughly described.
-<li>
   <a href="verify.html">verify</a> curl and how curl is verified
 <li>
   <a href="versions.html">version numbering</a> - described
-<li>
-  <a href="vulnerabilities.html">vulnerabilities</a> - shows which
-  versions that are vulnerable to each problem.
-<li>
-  <a href="/dev/vuln-disclosure.html">Vulnerability Disclosure Policy</a>
-
 </ul>
 
 #include "_footer.html"

--- a/docs/_secdocs.html
+++ b/docs/_secdocs.html
@@ -1,0 +1,46 @@
+#include "_doctype.html"
+<html>
+<head> <title>curl - Security Documentation</title>
+#include "css.t"
+</head>
+
+#define CURL_DOCS
+#define CURL_URL docs/secdocs.html
+
+#define SEC_DOCS
+#include "_menu.html"
+#include "setup.t"
+
+WHERE2(Docs, "/docs/", Security)
+
+TITLE(Security)
+<div class="relatedbox">
+<b>Related:</b>
+<br><a href="/docs/">Docs Overview</a>
+<br><a href="/dev/">Development docs</a>
+<br><a href="projdocs.html">Project docs</a>
+<br><a href="reldocs.html">Release docs</a>
+</div>
+<p>
+  Information related to curl security.
+
+<ul>
+  <li>
+    <a href="audits.html">Security Audits</a> - listed, including results and
+    reports.
+  <li>
+    <a href="security.html">curl CVE page</a> - all publicized security problems
+    listed and thoroughly described.
+  <li><a href="/dev/advisory.html">Security advisory details</a> - how to write
+    a curl security advisory.
+  <li>
+    <a href="vulnerabilities.html">vulnerability table</a> - shows which
+    versions that are vulnerable to each problem.
+  <li>
+    <a href="/dev/vuln-disclosure.html">Vulnerability Disclosure Policy</a> -
+    where to report them and how we deal with vulnerability reports
+</ul>
+
+#include "_footer.html"
+</body>
+</html>


### PR DESCRIPTION
It was not obvious that the security related information would be on the releases page. I also think security is important enough to deserve to be on top-level.